### PR TITLE
Allowed shell commands in script

### DIFF
--- a/scripts/pyver
+++ b/scripts/pyver
@@ -1,29 +1,44 @@
 #!/usr/bin/env python
-# Import and print the library version and filesystem location for each Python package specified
+# Import and print the library version and filesystem location for each Python package or shell command specified
 #
-# bash usage: $ pyver numpy pandas 
-# python usage: >>> import pyver ; pyver("numpy","pandas")
+# bash usage: $ pyver numpy pandas python conda
+# python usage: >>> import pyver ; pyver("numpy","pandas","python","conda")
 
 from __future__ import print_function
-import os.path, importlib
+import os.path, importlib, subprocess
 
 def pyver(*packages):
     """Import and print location and version information for specified Python packages"""
     for package in packages:
-        loc = "not installed"
+        loc = "not installed in this environment"
         ver = "unknown"
-        
+
         try:
             module = importlib.import_module(package)
             loc =  os.path.dirname(module.__file__)
-
+    
             try:
                 ver = str(module.__version__)
             except Exception:
                 pass
         
-        except ImportError:
-            pass
+        except (ImportError, ModuleNotFoundError):
+            try:
+                # See if there is a command by that name and check its --version if so
+                loc = subprocess.check_output(['which', package]).decode().strip()
+                out = ""
+                try:
+                    out = subprocess.check_output([package, '--version'], stderr=subprocess.STDOUT)
+                except subprocess.CalledProcessError as e:
+                    out = e.output
+
+                # Assume first word in output with a period and digits is the version
+                for s in out.decode().split():
+                    if '.' in s and sum(str.isdigit(c) for c in s)>=2:
+                        ver=s.strip()
+                        break
+            except Exception as e:
+                pass
         
         print("{0:30} # {1}".format(package + "=" + ver,loc))
 

--- a/scripts/pyver
+++ b/scripts/pyver
@@ -16,7 +16,7 @@ def pyver(*packages):
         try:
             module = importlib.import_module(package)
             loc =  os.path.dirname(module.__file__)
-    
+
             try:
                 ver = str(module.__version__)
             except Exception:


### PR DESCRIPTION
People often want to know the python and conda versions as well as python library versions, so if the supplied arguments aren't Python libraries, it tries running them as commands with ``--version``.  