### PR TITLE
PEP440 and "version always up to date" tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,13 @@ jobs:
       script:
         ### (1) verify installed python package
         - GIT_VERSION=$(git describe --long) tox -e $TOX_ENV
-        ### (2) verify autover imported from github source dir
-        - python scripts/tmpverify
+        ### (2) verify in this git checkout
+        - PYTHONPATH=. ./scripts/tmpverify
+        ### (3) verify develop install
+        - pip install -e .
+	- mkdir $HOME/tmp123
+	- cd $HOME/tmp123
+        - GIT_VERSION=$(git describe --long) tmpverify
 
     - stage: conda_package
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 stages:
   - test
   - name: conda_package
-    if: (branch = master AND type != pull_request) OR (tag IS present)
+#    if: (branch = master AND type != pull_request) OR (tag IS present)
   - name: pypi_package
     if: tag IS present
 
@@ -15,16 +15,21 @@ jobs:
   include:
     - &tests
       stage: test
-      python: 3.6
-      env: TOX_ENV=py36
+      python: 2.7
+      env: TOX_ENV=py27
       install:
         - pip install tox
       script:
         - tox -e $TOX_ENV
 
     - <<: *tests
-      python: 2.7
-      env: TOX_ENV=py27
+      python: 3.6
+      env: TOX_ENV=py36
+      script:
+        ### (1) verify installed python package
+        - GIT_VERSION=$(git describe --long) tox -e $TOX_ENV
+        ### (2) verify autover imported from github source dir
+        - scripts/tmpverify
 
     - stage: conda_package
       install:
@@ -38,7 +43,7 @@ jobs:
         - conda build conda.recipe
       after_success:
         - export LABEL="--label dev" && [[ ! -z "$TRAVIS_TAG" ]] && LABEL=""
-        - anaconda --token $CONDA_UPLOAD_TOKEN upload --user cball ${LABEL} $(conda build --output conda.recipe)
+#        - anaconda --token $CONDA_UPLOAD_TOKEN upload --user cball ${LABEL} $(conda build --output conda.recipe)
 
     - <<: *tests
       stage: pypi_package

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         ### (1) verify installed python package
         - GIT_VERSION=$(git describe --long) tox -e $TOX_ENV
         ### (2) verify autover imported from github source dir
-        - scripts/tmpverify
+        - python scripts/tmpverify
 
     - stage: conda_package
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,11 @@ jobs:
         ### (2) verify in this git checkout
         - PYTHONPATH=. ./scripts/tmpverify
         ### (3) verify develop install
+        - export GIT_VERSION=$(git describe --long)
         - pip install -e .
         - mkdir $HOME/tmp123
         - cd $HOME/tmp123
-        - GIT_VERSION=$(git describe --long) tmpverify
+        - tmpverify
 
     - stage: conda_package
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
         - PYTHONPATH=. ./scripts/tmpverify
         ### (3) verify develop install
         - pip install -e .
-	- mkdir $HOME/tmp123
-	- cd $HOME/tmp123
+        - mkdir $HOME/tmp123
+        - cd $HOME/tmp123
         - GIT_VERSION=$(git describe --long) tmpverify
 
     - stage: conda_package

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -18,6 +18,9 @@ requirements:
 test:
   imports:
     - autover
+  commands:
+    # verify conda-installed autover
+    - tmpverify {{ environ['GIT_DESCRIBE_TAG'] }} {{ environ['GIT_DESCRIBE_NUMBER'] }} {{ environ['GIT_DESCRIBE_HASH'] }}
 
 about:
   home: https://github.com/ioam/autover

--- a/scripts/tmpverify
+++ b/scripts/tmpverify
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import autover
+
+###############
+# (1) pep440 compliant?
+import pkg_resources._vendor.packaging.version as packaging_version
+packaging_version.Version(str(autover.__version__))
+
+###############
+# (2) following desired 'predicted version' scheme?
+import subprocess
+import sys
+import os
+
+GIT_VERSION = os.environ.get("GIT_VERSION")
+
+if len(sys.argv)>1:
+    v=sys.argv[1]
+    commits=sys.argv[2]
+    sha=sys.argv[3]
+    print("Git info read from arguments: %s %s %s"%(v,commits,sha))
+elif GIT_VERSION is not None:
+    v,commits,sha=GIT_VERSION.split('-')
+    print("Git info read from GIT_VERSION: %s %s %s"%(v,commits,sha))
+else:
+    desc=subprocess.check_output(['git','describe','--long']).decode('utf8')
+    v,commits,sha=desc.split('-')
+    print("Git info collected from git: %s %s %s"%(v,commits,sha))
+
+newv=[int(x) for x in v[1::].split('.')];
+newv[-1]+=1;
+predicted_version='.'.join(str(x) for x in newv)+'.dev'+commits+"+"+sha;
+
+assert autover.__version__==predicted_version, '%s != %s'%(autover.__version__,predicted_version)
+
+###############
+# (3) setup.py version matches __version__ (only relevant in a source dir)
+try:
+    import setup
+    assert setup.setup_args['version'] == str(autover.__version__), 'setup version %s != autover.__version__ %s'%(setup.setup_args['version'], str(autover.__version__))
+except ImportError:
+    print("skipping setup.py check")

--- a/scripts/tmpverify
+++ b/scripts/tmpverify
@@ -8,7 +8,8 @@ import pkg_resources._vendor.packaging.version as packaging_version
 packaging_version.Version(str(autover.__version__))
 
 ###############
-# (2) following desired 'predicted version' scheme?
+# (2) following desired 'predicted version + hash' scheme?
+# v0.2.0-5-g85da374 --> 0.2.1.dev5+g85da374
 import subprocess
 import sys
 import os

--- a/scripts/tmpverify
+++ b/scripts/tmpverify
@@ -3,12 +3,12 @@
 import autover
 
 ###############
-# (1) pep440 compliant?
+# (a) pep440 compliant?
 import pkg_resources._vendor.packaging.version as packaging_version
 packaging_version.Version(str(autover.__version__))
 
 ###############
-# (2) following desired 'predicted version + hash' scheme?
+# (b) following desired 'predicted version + hash' scheme?
 # v0.2.0-5-g85da374 --> 0.2.1.dev5+g85da374
 import subprocess
 import sys
@@ -36,7 +36,7 @@ predicted_version='.'.join(str(x) for x in newv)+'.dev'+commits+"+"+sha;
 assert autover.__version__==predicted_version, '%s != %s'%(autover.__version__,predicted_version)
 
 ###############
-# (3) setup.py version matches __version__ (only relevant in a source dir)
+# (c) setup.py version matches __version__ (only relevant in a source dir)
 try:
     import setup
     assert setup.setup_args['version'] == str(autover.__version__), 'setup version %s != autover.__version__ %s'%(setup.setup_args['version'], str(autover.__version__))

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup_args = dict(
     packages = ["autover"],
     provides = ["autover"],
     include_package_data=True,
-    scripts = ["scripts/autover"],
+    scripts = ["scripts/autover","scripts/tmpverify"],
     classifiers = [
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 2.7",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py36,py27
 [testenv]
 deps = nose
 commands = nosetests -vv --nologcapture --with-doctest --with-coverage --cover-package=autover
+           python -Werror -Wignore::DeprecationWarning setup.py --version
 
 [testenv:lint_checks]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 envlist = py36,py27
 
 [testenv]
+passenv = GIT_VERSION
 deps = nose
 commands = nosetests -vv --nologcapture --with-doctest --with-coverage --cover-package=autover
-           python -Werror -Wignore::DeprecationWarning setup.py --version
+           tmpverify
 
 [testenv:lint_checks]
 deps = flake8


### PR DESCRIPTION
I'm trying to get "the correct version" for a python package when it's imported from: (1) setup.py install, (2) git dir, (3) setup.py develop, (4) conda install. (A more lengthy discussion of these is in #2.)

This PR introduces a hacky test script that's run in the 4 scenarios above, and which so far checks 3 things about the version are correct (see comments a, b, c in script).

```python
# (a) pep440 compliant?

# (b) following desired 'predicted version + hash' scheme?
# v0.2.0-5-g85da374 --> 0.2.1.dev5+g85da374

# (c) setup.py version matches __version__ (only relevant in a source dir)
```

(Note: are those requirements correct, plus what did I miss?)

Travis runs this script for the 4 scenarios above.

![screen shot 2018-01-23 at 12 16 33 am](https://user-images.githubusercontent.com/1929/35273267-f142dc4e-002f-11e8-9fa3-7d679024cf28.png)

The errors (linked below) currently all come from the script’s pep440 check.

(1) python package is created and then installed, then verify script is run. Using tox on travis, but the commands are just: `python setup.py sdist` followed by `python setup.py install` of the resulting dist into fresh environment, followed by running `tmpverify` with the repo's git info. Error at https://travis-ci.org/ioam/autover/jobs/332076327#L495

(2) just import from this git clone. Error at https://travis-ci.org/ioam/autover/jobs/332076327#L507

(3) `pip install -e .` or `python setup.py develop`, then `tmpverify` with repo’s git info. Error at https://travis-ci.org/ioam/autover/jobs/332076327#L544

(4) happens when the conda package is built i.e. you run `conda build conda.recipe` (which installs and tests too)

![screen shot 2018-01-23 at 12 07 29 am](https://user-images.githubusercontent.com/1929/35273417-7e482b26-0030-11e8-82b0-ba274346832a.png)

Travis skips this because of earlier errors 1-3 above. However, running the command locally you get something like

```
$ conda build conda.recipe
Copying /Users/cball/code/ioam/autover to /Users/cball/abc/conda-bld/autover_1516666769427/work
Attempting to finalize metadata for autover
INFO:conda_build.metadata:Attempting to finalize metadata for autover
Solving environment: done
Solving environment: done
BUILD START: ['autover-0.2.0.7_g7dddba2-pyh082aade_0.tar.bz2']

[...]

+ tmpverify v0.2.0 7 g7dddba2
Traceback (most recent call last):
  File "/Users/cball/abc/conda-bld/autover_1516666769427/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/bin/tmpverify", line 8, in <module>
    packaging_version.Version(str(autover.__version__))
  File "/Users/cball/abc/conda-bld/autover_1516666769427/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/version.py", line 202, in __init__
    raise InvalidVersion("Invalid version: '{0}'".format(version))
pkg_resources._vendor.packaging.version.InvalidVersion: Invalid version: '0.2.0-7-g7dddba2'
Tests failed for autover-0.2.0.7_g7dddba2-pyh082aade_0.tar.bz2 - moving package to /Users/cball/abc/conda-bld/broken
```
