### PR TITLE
Initial go at example getting autover from param.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -282,4 +282,4 @@ jobs:
         - doit $EXTRA copy_example_project --example=$MODULE
         - doit $EXTRA git_init
       script:
-        - doit $EXTRA -c pyviz/label/dev build_conda_package
+        - doit $EXTRA build_conda_package -c pyviz/label/dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,16 @@ jobs:
       install: true
 
     - <<: *example_tests
+      python: 3.6
+      env:
+        - DESC="example"
+        - MODULE=pkg_params
+        - EXTRA="--dir=/tmp/123"
+      install:
+        # build param package so it's available for tox
+        - doit build_param_package
+
+    - <<: *example_tests
       python: 3.6    
       env:
         - DESC="example pip+git"
@@ -95,6 +105,17 @@ jobs:
       env:
         - DESC="example pip+git"
         - MODULE=pkg_bundle
+        - EXTRA="--dir=/tmp/123"
+      install:
+        - pip install git+file:///tmp/123
+      script:
+        - doit $EXTRA verify_installed_version --example=$MODULE
+
+    - <<: *example_tests
+      python: 3.6    
+      env:
+        - DESC="example pip+git"
+        - MODULE=pkg_params
         - EXTRA="--dir=/tmp/123"
       install:
         - pip install git+file:///tmp/123
@@ -132,6 +153,16 @@ jobs:
       install: true
 
     - <<: *example_tests
+      python: 2.7
+      env:
+        - DESC="example"
+        - MODULE=pkg_params
+        - EXTRA="--dir=/tmp/123"
+      install:
+        # build param package so it's available for tox
+        - doit build_param_package
+
+    - <<: *example_tests
       python: 2.7    
       env:
         - DESC="example pip+git"
@@ -147,6 +178,17 @@ jobs:
       env:
         - DESC="example pip+git"
         - MODULE=pkg_bundle
+        - EXTRA="--dir=/tmp/123"
+      install:
+        - pip install git+file:///tmp/123
+      script:
+        - doit $EXTRA verify_installed_version --example=$MODULE
+
+    - <<: *example_tests
+      python: 2.7    
+      env:
+        - DESC="example pip+git"
+        - MODULE=pkg_params
         - EXTRA="--dir=/tmp/123"
       install:
         - pip install git+file:///tmp/123
@@ -228,3 +270,16 @@ jobs:
       script:
         - doit build_conda_package
         - doit $EXTRA build_conda_package
+
+    - <<: *conda_default
+      stage: test
+      env:
+        - DESC="example conda"
+        - MODULE=pkg_params
+        - EXTRA="--dir=/tmp/123"
+      install:
+        - mkdir /tmp/123
+        - doit $EXTRA copy_example_project --example=$MODULE
+        - doit $EXTRA git_init
+      script:
+        - doit $EXTRA -c pyviz/label/dev build_conda_package

--- a/dodo.py
+++ b/dodo.py
@@ -79,3 +79,6 @@ def task_original_script():
             action.CmdAction('pip uninstall -y %(example)s')
         ]
     }
+
+def task_build_param_package():
+    return {'actions': ['git clone https://github.com/ioam/param.git && cd param && python setup.py bdist_wheel']}

--- a/dodo.py
+++ b/dodo.py
@@ -81,4 +81,5 @@ def task_original_script():
     }
 
 def task_build_param_package():
-    return {'actions': ['git clone https://github.com/ioam/param.git && cd param && python setup.py bdist_wheel']}
+    shared_packages = os.path.join(doit.get_initial_workdir(), "dist")    
+    return {'actions': ['git clone https://github.com/ioam/param.git && cd param && python setup.py bdist_wheel -d %s'%shared_packages]}

--- a/examples/pkg_params/.gitignore
+++ b/examples/pkg_params/.gitignore
@@ -1,0 +1,4 @@
+.doit*
+*.pyc
+*~
+*egg-info

--- a/examples/pkg_params/conda.recipe/meta.yaml
+++ b/examples/pkg_params/conda.recipe/meta.yaml
@@ -1,0 +1,32 @@
+{% set sdata = load_setup_py_data() %}
+
+package:
+  name: pkg_params
+  version: {{ sdata['version'] }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - param
+  run:
+    - python
+    - param
+
+test:
+  imports:
+    - pkg_params
+  commands:
+    - tmpverify pkg_params {{ environ['GIT_DESCRIBE_TAG'] }} {{ environ['GIT_DESCRIBE_NUMBER'] }} {{ environ['GIT_DESCRIBE_HASH'] }}
+
+about:
+  home: {{ sdata['url'] }}
+  summary: {{ sdata['description'] }}
+  license: {{ sdata['license'] }}

--- a/examples/pkg_params/pkg_params/__init__.py
+++ b/examples/pkg_params/pkg_params/__init__.py
@@ -1,0 +1,11 @@
+try:    from param.version import Version
+except: from .version import Version
+
+try:
+    versionobj = Version(release=None, fpath=__file__,
+                         archive_commit="$Format:%h$", reponame="pkg_params")
+    __version__ = str(versionobj)
+except:
+    import os, json
+    __version__ = json.load(open(os.path.join(os.path.split(__file__)[0],
+                                              '.version'), 'r'))['version_string']

--- a/examples/pkg_params/pkg_params/tests/__init__.py
+++ b/examples/pkg_params/pkg_params/tests/__init__.py
@@ -1,0 +1,56 @@
+import sys
+import pkg_resources._vendor.packaging.version as packaging_version
+import subprocess
+import os
+
+
+def main():
+
+    module_name = sys.argv[1]
+    module = __import__(module_name)
+
+    ###############
+    # (a) pep440 compliant?
+    packaging_version.Version(module.__version__)
+
+    ###############
+    # (b) following desired 'latest master' version scheme?
+    # v0.2.0-5-g85da374 --> 0.2.0.post5+g85da374
+
+    if len(sys.argv)==5:
+        v=sys.argv[2]
+        commits=sys.argv[3]
+        sha=sys.argv[4]
+        print("Git info supplied: %s %s %s"%(v,commits,sha))
+    elif len(sys.argv)==3:
+        v,commits,sha=sys.argv[2].split('-')
+        print("Git info supplied: %s %s %s"%(v,commits,sha))
+    elif len(sys.argv)==2:
+        desc=subprocess.check_output(['git','describe','--long']).decode('utf8').strip()
+        v,commits,sha=desc.split('-')
+        print("Git info collected from git in %s: %s %s %s"%(os.getcwd(),v,commits,sha))
+    else:
+        raise ValueError
+
+    expected_version=v[1::]
+    if int(commits) > 0:
+        expected_version += '.post'+commits+"+"+sha;
+
+    assert module.__version__ == expected_version, '%s.__version__ %r does not match %r' % (module_name,module.__version__,expected_version)
+
+    ###############
+    # (c) setup.py version matches __version__ (only relevant in a source dir)
+    if os.path.exists("setup.py"):
+        print(os.getcwd())
+        print(sys.path)
+        try:
+            import setup
+        except ImportError:
+            print("skipping setup.py check")
+            import traceback
+            traceback.print_exc()
+        else:
+            print(setup.__file__)
+            assert module.__version__ == setup.setup_args['version'], '%s.__version__ %r does not match setup version %r'%(module_name,module.__version__, setup.setup_args['version'])
+    else:
+        print("No setup.py in %s; skipping test."%os.getcwd())

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -1,0 +1,66 @@
+import os
+import json
+import importlib
+
+from setuptools import setup, find_packages
+
+def embed_version(basepath, reponame, ref='v0.2.1'):
+    """
+    Autover is purely a build time dependency in all cases (conda and
+    pip) except for when you use pip's remote git support [git+url] as
+    1) you need a dynamically changing version and 2) the environment
+    starts off clean with zero dependencies installed.
+
+    This function acts as a fallback to make Version available until
+    PEP518 is commonly supported by pip to express build dependencies.
+    """
+    import io, zipfile
+    try:    from urllib.request import urlopen
+    except: from urllib import urlopen
+    response = urlopen('https://github.com/ioam/autover/archive/{ref}.zip'.format(ref=ref))
+    zf = zipfile.ZipFile(io.BytesIO(response.read()))
+    ref = ref[1:] if ref.startswith('v') else ref
+    embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
+    with open(os.path.join(basepath, reponame, 'version.py'), 'wb') as f:
+        f.write(embed_version)
+
+
+def get_setup_version(reponame):
+    """
+    Helper to get the current version from either git describe or the
+    .version file (if available).
+    """
+    basepath = os.path.split(__file__)[0]
+    version_file_path = os.path.join(basepath, reponame, '.version')
+    version = None
+    try: version = importlib.import_module(reponame + ".version") # Bundled
+    except:  # autover available as package
+        try: from autover import version
+        except:
+            try: from param import version # Try to get it from param
+            except:
+                embed_version(basepath, reponame)
+                version = importlib.import_module(reponame + ".version")
+
+    if version is not None:
+        return version.Version.setup_version(basepath, reponame, dirty='strip',
+                                             archive_commit="$Format:%h$")
+    else:
+        return json.load(open(version_file_path, 'r'))['version_string']
+
+setup_args = dict(
+    name='pkg_params',
+    version=get_setup_version("pkg_params"),
+    packages = find_packages(),
+    package_data = {'pkg_params': ['.version']},
+    entry_points = {
+        'console_scripts': ['tmpverify=pkg_params.tests:main'],
+    },
+    url = "http://",
+    license = "BSD",
+    description = "Example of depending on autover via param"
+)
+
+
+if __name__=="__main__":
+    setup(**setup_args)

--- a/examples/pkg_params/tox.ini
+++ b/examples/pkg_params/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py36
+
+[testenv]
+passenv = GIT_VERSION
+install_command = pip install --pre --no-index -f {env:SHARED_PACKAGES} {opts} {packages}
+deps = param
+commands = tmpverify pkg_params


### PR DESCRIPTION
This adds an example of using autover via param. My understanding is that this is how ioam/pyviz projects want to use autover; hopefully everyone will be able to copy how it's done in this example package.

For pip, latest param master package is built and used for testing.
For conda, the most recent dev conda package (from pyviz/label/dev) is used for testing.