### PR TITLE
Fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.o
 *.out
 *.lock
+*.doit*

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
         - doit $EXTRA git_init
       install:
         - pip install -e .
-        # build package so it's available for tox
+        # build package so it's available for pip
         - python setup.py bdist_wheel
       script:
         - doit $EXTRA original_script --example=$MODULE
@@ -68,7 +68,7 @@ jobs:
         - MODULE=pkg_depend
         - EXTRA="--dir=/tmp/123"
       install:
-        # build package so it's available for tox
+        # build package so it's available for pip
         - python setup.py bdist_wheel
 
     - <<: *example_tests
@@ -143,7 +143,7 @@ jobs:
         - MODULE=pkg_depend
         - EXTRA="--dir=/tmp/123"
       install:
-        # build package so it's available for tox
+        # build package so it's available for pip
         - python setup.py bdist_wheel
 
     - <<: *example_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - MODULE=pkg_params
         - EXTRA="--dir=/tmp/123"
       install:
-        # build param package so it's available for tox
+        # build param package so it's available for pip
         - doit build_param_package
 
     - <<: *example_tests
@@ -159,7 +159,7 @@ jobs:
         - MODULE=pkg_params
         - EXTRA="--dir=/tmp/123"
       install:
-        # build param package so it's available for tox
+        # build param package so it's available for pip
         - doit build_param_package
 
     - <<: *example_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -198,6 +198,19 @@ jobs:
       script:
         - doit $EXTRA verify_installed_version --example=$MODULE
 
+##############################
+
+# test that dirty detection works
+# should fail; replace with unit test
+
+    - <<: *example_tests
+      python: 3.6
+      env:
+        - DESC="check dirty"
+        - MODULE=pkg_bundle
+        - EXTRA="--dir=/tmp/123"
+      install:
+        - echo '#dirty' >> /tmp/123/setup.py
 
 ##############################
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -208,8 +208,7 @@ jobs:
         - DESC="check dirty"
         - MODULE=pkg_bundle
         - EXTRA="--dir=/tmp/123"
-      install:
-        - echo '#dirty' >> /tmp/123/setup.py
+      install: true
       script:
         - doit $EXTRA check_dirty_detection
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -200,17 +200,18 @@ jobs:
 
 ##############################
 
-## test that dirty detection works
-## should fail; replace with unit test
-#
-#    - <<: *example_tests
-#      python: 3.6
-#      env:
-#        - DESC="check dirty"
-#        - MODULE=pkg_bundle
-#        - EXTRA="--dir=/tmp/123"
-#      install:
-#        - echo '#dirty' >> /tmp/123/setup.py
+# test that dirty detection works
+
+    - <<: *example_tests
+      python: 3.6
+      env:
+        - DESC="check dirty"
+        - MODULE=pkg_bundle
+        - EXTRA="--dir=/tmp/123"
+      install:
+        - echo '#dirty' >> /tmp/123/setup.py
+      script:
+        - doit $EXTRA check_dirty_detection
 
 ##############################
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,9 @@ jobs:
         - MODULE=pkg_params
         - EXTRA="--dir=/tmp/123"
       install:
-        - pip install git+file:///tmp/123
+        - doit build_param_package      
+        # TODO: should move to doit (same comment for other places this is done)
+        - pip install -f $TRAVIS_BUILD_DIR/dist git+file:///tmp/123
       script:
         - doit $EXTRA verify_installed_version --example=$MODULE
 
@@ -191,7 +193,8 @@ jobs:
         - MODULE=pkg_params
         - EXTRA="--dir=/tmp/123"
       install:
-        - pip install git+file:///tmp/123
+        - doit build_param_package
+        - pip install -f $TRAVIS_BUILD_DIR/dist git+file:///tmp/123      
       script:
         - doit $EXTRA verify_installed_version --example=$MODULE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -200,17 +200,17 @@ jobs:
 
 ##############################
 
-# test that dirty detection works
-# should fail; replace with unit test
-
-    - <<: *example_tests
-      python: 3.6
-      env:
-        - DESC="check dirty"
-        - MODULE=pkg_bundle
-        - EXTRA="--dir=/tmp/123"
-      install:
-        - echo '#dirty' >> /tmp/123/setup.py
+## test that dirty detection works
+## should fail; replace with unit test
+#
+#    - <<: *example_tests
+#      python: 3.6
+#      env:
+#        - DESC="check dirty"
+#        - MODULE=pkg_bundle
+#        - EXTRA="--dir=/tmp/123"
+#      install:
+#        - echo '#dirty' >> /tmp/123/setup.py
 
 ##############################
 

--- a/autover/version.py
+++ b/autover/version.py
@@ -423,7 +423,7 @@ class Version(object):
 
     @classmethod
     def get_setup_version(cls, setup_path, reponame, describe=False,
-                          dirty='strip', archive_commit=None):
+                          dirty='raise', archive_commit=None):
         """
         Helper for use in setup.py to get the version from the .version file (if available)
         or more up-to-date information from git describe (if available).

--- a/autover/version.py
+++ b/autover/version.py
@@ -461,7 +461,7 @@ class Version(object):
             return vstring
 
     @classmethod
-    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='strip'):
+    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='raise'):
         vstring =  Version.get_setup_version(setup_path,
                                              reponame,
                                              describe=False,

--- a/dodo.py
+++ b/dodo.py
@@ -86,7 +86,7 @@ def task_build_param_package():
     return {'actions': ['git clone https://github.com/ioam/param.git && cd param && python setup.py bdist_wheel -d %s'%shared_packages]}
 
 def task_check_dirty_detection():
-    
+    # TODO: test should be less bash
     return {'actions':[
         'echo "#dirty" >> setup.py',
         '! python setup.py sdist > test-dirty-check 2>&1',

--- a/dodo.py
+++ b/dodo.py
@@ -87,10 +87,14 @@ def task_build_param_package():
 
 def task_check_dirty_detection():
     # TODO: test should be less bash
-    return {'actions':[
-        'echo "#dirty" >> setup.py',
-        '! python setup.py sdist > test-dirty-check 2>&1',
-        'grep "AssertionError: Repository is in a dirty state." test-dirty-check'
-    ]}
+    return {
+        'actions':[
+            'echo "#dirty" >> setup.py',
+            'git describe --dirty --long',
+            '! python setup.py sdist > test-dirty-check 2>&1',
+            'grep "AssertionError: Repository is in a dirty state." test-dirty-check'
+        ],
+        'teardown':[
+            'cat test-dirty-check'
+        ]}
 
-        

--- a/dodo.py
+++ b/dodo.py
@@ -59,8 +59,9 @@ def task_verify_installed_version():
 
 # TODO: split up
 def task_original_script():
+    shared_packages = os.path.join(doit.get_initial_workdir(), "dist")
     env1 = os.environ.copy()
-    env1['SHARED_PACKAGES'] = os.path.join(doit.get_initial_workdir(), "dist")
+    env1['SHARED_PACKAGES'] = shared_packages
 
     env2 = os.environ.copy()
     env2['PYTHONPATH'] = os.getcwd() # TODO win
@@ -74,7 +75,7 @@ def task_original_script():
             # 2. verify in git repo
             action.CmdAction('python %(example)s/tests/__init__.py %(example)s',env=env2),
             # 3. verify develop install
-            action.CmdAction('pip install -e . && mkdir /tmp/9k && cd /tmp/9k && tmpverify %(example)s %(git_version)s',env=env2),
+            action.CmdAction('pip install -f ' + shared_packages + ' -e . && mkdir /tmp/9k && cd /tmp/9k && tmpverify %(example)s %(git_version)s',env=env2),
             # TODO: should be some kind of clean up option
             action.CmdAction('pip uninstall -y %(example)s')
         ]

--- a/dodo.py
+++ b/dodo.py
@@ -84,3 +84,13 @@ def task_original_script():
 def task_build_param_package():
     shared_packages = os.path.join(doit.get_initial_workdir(), "dist")    
     return {'actions': ['git clone https://github.com/ioam/param.git && cd param && python setup.py bdist_wheel -d %s'%shared_packages]}
+
+def task_check_dirty_detection():
+    
+    return {'actions':[
+        'echo "#dirty" >> setup.py',
+        '! python setup.py sdist > test-dirty-check 2>&1',
+        'grep "AssertionError: Repository is in a dirty state." test-dirty-check'
+    ]}
+
+        

--- a/examples/pkg_bundle/pkg_bundle/__init__.py
+++ b/examples/pkg_bundle/pkg_bundle/__init__.py
@@ -1,11 +1,4 @@
-try:    from autover.version import Version
-except: from .version import Version
+from .version import Version
 
-try:
-    versionobj = Version(release=None, fpath=__file__,
-                         archive_commit="$Format:%h$", reponame="pkg_bundle")
-    __version__ = str(versionobj)
-except:
-    import os, json
-    __version__ = json.load(open(os.path.join(os.path.split(__file__)[0],
-                                              '.version'), 'r'))['version_string']
+versionobj = Version(fpath=__file__,archive_commit="$Format:%h$", reponame="pkg_bundle")
+__version__ = str(versionobj)

--- a/examples/pkg_bundle/pkg_bundle/version.py
+++ b/examples/pkg_bundle/pkg_bundle/version.py
@@ -461,7 +461,7 @@ class Version(object):
             return vstring
 
     @classmethod
-    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='strip'):
+    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='raise'):
         vstring =  Version.get_setup_version(setup_path,
                                              reponame,
                                              describe=False,

--- a/examples/pkg_bundle/pkg_bundle/version.py
+++ b/examples/pkg_bundle/pkg_bundle/version.py
@@ -168,7 +168,7 @@ class Version(object):
     supplied."""
 
     def __init__(self, release=None, fpath=None, commit=None, reponame=None,
-                 commit_count_prefix='.post', archive_commit=None):
+                 commit_count_prefix='.post', archive_commit=None, **kwargs):
         """
         :release:      Release tuple (corresponding to the current VCS tag)
         :commit        Short SHA. Set to '$Format:%h$' for git archive support.
@@ -177,6 +177,10 @@ class Version(object):
         """
         self.fpath = fpath
         self._expected_commit = commit
+
+        if release is not None or 'commit_count' in kwargs:
+            print('WARNING: param.Version now supports PEP440 and a new tag based workflow. See param/version.py for more details')
+
         self.expected_release = release
 
         self._commit = None if (commit is None or commit.startswith("$Format")) else commit
@@ -419,7 +423,7 @@ class Version(object):
 
     @classmethod
     def get_setup_version(cls, setup_path, reponame, describe=False,
-                          dirty='strip', archive_commit=None):
+                          dirty='raise', archive_commit=None):
         """
         Helper for use in setup.py to get the version from the .version file (if available)
         or more up-to-date information from git describe (if available).

--- a/examples/pkg_bundle/setup.py
+++ b/examples/pkg_bundle/setup.py
@@ -43,8 +43,7 @@ def get_setup_version(reponame):
                 version = importlib.import_module("version")
 
     if version is not None:
-        return version.Version.setup_version(basepath, reponame, dirty='strip',
-                                             archive_commit="$Format:%h$")
+        return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
         return json.load(open(version_file_path, 'r'))['version_string']
 

--- a/examples/pkg_bundle/setup.py
+++ b/examples/pkg_bundle/setup.py
@@ -4,7 +4,7 @@ import importlib
 
 from setuptools import setup, find_packages
 
-def embed_version(basepath, reponame, ref='v0.2.1'):
+def embed_version(basepath, ref='v0.2.1'):
     """
     Autover is purely a build time dependency in all cases (conda and
     pip) except for when you use pip's remote git support [git+url] as
@@ -21,7 +21,7 @@ def embed_version(basepath, reponame, ref='v0.2.1'):
     zf = zipfile.ZipFile(io.BytesIO(response.read()))
     ref = ref[1:] if ref.startswith('v') else ref
     embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, reponame, 'version.py'), 'wb') as f:
+    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
         f.write(embed_version)
 
 
@@ -39,8 +39,8 @@ def get_setup_version(reponame):
         except:
             try: from param import version # Try to get it from param
             except:
-                embed_version(basepath, reponame)
-                version = importlib.import_module(reponame + ".version")
+                embed_version(basepath)
+                version = importlib.import_module("version")
 
     if version is not None:
         return version.Version.setup_version(basepath, reponame, dirty='strip',
@@ -54,6 +54,7 @@ setup_args = dict(
     version=get_setup_version("pkg_bundle"),
     packages = find_packages(),
     package_data = {'pkg_bundle': ['.version']},
+    include_package_data=True,    
     entry_points = {
         'console_scripts': ['tmpverify=pkg_bundle.tests:main'],
     },

--- a/examples/pkg_bundle/setup.py
+++ b/examples/pkg_bundle/setup.py
@@ -45,6 +45,7 @@ def get_setup_version(reponame):
     if version is not None:
         return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
+        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")        
         return json.load(open(version_file_path, 'r'))['version_string']
 
 

--- a/examples/pkg_depend/conda.recipe/meta.yaml
+++ b/examples/pkg_depend/conda.recipe/meta.yaml
@@ -18,6 +18,12 @@ requirements:
     - autover
   run:
     - python
+    # autover is listed in setup.py install_requires; when the console
+    # script (tmpverify) is run, python will attempt to install
+    # autover if autover's not already installed. Therefore, make
+    # runtime dependency explicit here. (Alternative would be to add
+    # autover under 'test requires'?)
+    - autover
 
 test:
   imports:

--- a/examples/pkg_depend/pkg_depend/__init__.py
+++ b/examples/pkg_depend/pkg_depend/__init__.py
@@ -1,6 +1,5 @@
-from autover.version import Version
-
 try:
+    from autover.version import Version
     versionobj = Version(release=None, fpath=__file__,
                          archive_commit="$Format:%h$", reponame="pkg_depend")
     __version__ = str(versionobj)

--- a/examples/pkg_depend/pkg_depend/__init__.py
+++ b/examples/pkg_depend/pkg_depend/__init__.py
@@ -1,5 +1,4 @@
-try:    from autover.version import Version
-except: from .version import Version
+from autover.version import Version
 
 try:
     versionobj = Version(release=None, fpath=__file__,

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -4,7 +4,7 @@ import importlib
 
 from setuptools import setup, find_packages
 
-def embed_version(basepath, reponame, ref='v0.2.1'):
+def embed_version(basepath, ref='v0.2.1'):
     """
     Autover is purely a build time dependency in all cases (conda and
     pip) except for when you use pip's remote git support [git+url] as
@@ -21,7 +21,7 @@ def embed_version(basepath, reponame, ref='v0.2.1'):
     zf = zipfile.ZipFile(io.BytesIO(response.read()))
     ref = ref[1:] if ref.startswith('v') else ref
     embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, reponame, 'version.py'), 'wb') as f:
+    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
         f.write(embed_version)
 
 
@@ -39,8 +39,8 @@ def get_setup_version(reponame):
         except:
             try: from param import version # Try to get it from param
             except:
-                embed_version(basepath, reponame)
-                version = importlib.import_module(reponame + ".version")
+                embed_version(basepath)
+                version = importlib.import_module("version")
 
     if version is not None:
         return version.Version.setup_version(basepath, reponame, dirty='strip',

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -53,6 +53,7 @@ setup_args = dict(
     version=get_setup_version("pkg_depend"),
     packages = find_packages(),
     package_data = {'pkg_depend': ['.version']},
+    include_package_data = True,
     entry_points = {
         'console_scripts': ['tmpverify=pkg_depend.tests:main'],
     },

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -43,8 +43,7 @@ def get_setup_version(reponame):
                 version = importlib.import_module("version")
 
     if version is not None:
-        return version.Version.setup_version(basepath, reponame, dirty='strip',
-                                             archive_commit="$Format:%h$")
+        return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
         return json.load(open(version_file_path, 'r'))['version_string']
 

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -45,6 +45,7 @@ def get_setup_version(reponame):
     if version is not None:
         return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
+        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")        
         return json.load(open(version_file_path, 'r'))['version_string']
 
 setup_args = dict(

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -57,6 +57,7 @@ setup_args = dict(
     entry_points = {
         'console_scripts': ['tmpverify=pkg_depend.tests:main'],
     },
+    install_requires = ['autover'],
     url = "http://",
     license = "BSD",
     description = "Example of depending on autover"

--- a/examples/pkg_depend/tox.ini
+++ b/examples/pkg_depend/tox.ini
@@ -4,5 +4,4 @@ envlist = py36
 [testenv]
 passenv = GIT_VERSION
 install_command = pip install --pre --no-index -f {env:SHARED_PACKAGES} {opts} {packages}
-deps = autover
 commands = tmpverify pkg_depend

--- a/examples/pkg_json_fallback/setup.py
+++ b/examples/pkg_json_fallback/setup.py
@@ -3,7 +3,7 @@ import json
 
 from setuptools import setup, find_packages
 
-def embed_version(basepath, reponame, ref='v0.2.1'):
+def embed_version(basepath, ref='v0.2.1'):
     """
     Autover is purely a build time dependency in all cases (conda and
     pip) except for when you use pip's remote git support [git+url] as
@@ -20,7 +20,7 @@ def embed_version(basepath, reponame, ref='v0.2.1'):
     zf = zipfile.ZipFile(io.BytesIO(response.read()))
     ref = ref[1:] if ref.startswith('v') else ref
     embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, reponame, 'version.py'), 'wb') as f:
+    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
         f.write(embed_version)
 
 
@@ -40,6 +40,7 @@ setup_args = dict(
     version=get_setup_version("pkg_json_fallback"),
     packages = find_packages(),
     package_data = {'pkg_json_fallback': ['.version']},
+    include_package_data = True,
     entry_points = {
         'console_scripts': ['tmpverify=pkg_json_fallback.tests:main'],
     },

--- a/examples/pkg_json_fallback/tox.ini
+++ b/examples/pkg_json_fallback/tox.ini
@@ -4,5 +4,4 @@ envlist = py36
 [testenv]
 passenv = GIT_VERSION
 install_command = pip install --pre --no-index -f {env:SHARED_PACKAGES} {opts} {packages}
-deps = autover
 commands = tmpverify pkg_json_fallback

--- a/examples/pkg_params/conda.recipe/meta.yaml
+++ b/examples/pkg_params/conda.recipe/meta.yaml
@@ -15,10 +15,10 @@ requirements:
   build:
     - python
     - setuptools
-    - param
+    - param >1.5.1
   run:
     - python
-    - param
+    - param >1.5.1
 
 test:
   imports:

--- a/examples/pkg_params/pkg_params/__init__.py
+++ b/examples/pkg_params/pkg_params/__init__.py
@@ -1,11 +1,4 @@
-try:    from param.version import Version
-except: from .version import Version
+from param.version import Version
 
-try:
-    versionobj = Version(release=None, fpath=__file__,
-                         archive_commit="$Format:%h$", reponame="pkg_params")
-    __version__ = str(versionobj)
-except:
-    import os, json
-    __version__ = json.load(open(os.path.join(os.path.split(__file__)[0],
-                                              '.version'), 'r'))['version_string']
+versionobj = Version(fpath=__file__,archive_commit="$Format:%h$", reponame="pkg_params")
+__version__ = str(versionobj)

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -57,6 +57,7 @@ setup_args = dict(
     entry_points = {
         'console_scripts': ['tmpverify=pkg_params.tests:main'],
     },
+    install_requires = ['param'],
     url = "http://",
     license = "BSD",
     description = "Example of depending on autover via param"

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -57,7 +57,7 @@ setup_args = dict(
     entry_points = {
         'console_scripts': ['tmpverify=pkg_params.tests:main'],
     },
-    install_requires = ['param'],
+    install_requires = ['param >1.5.1'],
     url = "http://",
     license = "BSD",
     description = "Example of depending on autover via param"

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -43,8 +43,7 @@ def get_setup_version(reponame):
                 version = importlib.import_module("version")
 
     if version is not None:
-        return version.Version.setup_version(basepath, reponame, dirty='strip',
-                                             archive_commit="$Format:%h$")
+        return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
         return json.load(open(version_file_path, 'r'))['version_string']
 

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -57,7 +57,8 @@ setup_args = dict(
     entry_points = {
         'console_scripts': ['tmpverify=pkg_params.tests:main'],
     },
-    install_requires = ['param >1.5.1'],
+    # note: .post required (>1.5.1 won't match 1.5.1.postN+gSHA releases)
+    install_requires = ['param >=1.5.1.post26'],
     url = "http://",
     license = "BSD",
     description = "Example of depending on autover via param"

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -45,6 +45,7 @@ def get_setup_version(reponame):
     if version is not None:
         return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
+        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")        
         return json.load(open(version_file_path, 'r'))['version_string']
 
 setup_args = dict(

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -4,7 +4,7 @@ import importlib
 
 from setuptools import setup, find_packages
 
-def embed_version(basepath, reponame, ref='v0.2.1'):
+def embed_version(basepath, ref='v0.2.1'):
     """
     Autover is purely a build time dependency in all cases (conda and
     pip) except for when you use pip's remote git support [git+url] as
@@ -21,7 +21,7 @@ def embed_version(basepath, reponame, ref='v0.2.1'):
     zf = zipfile.ZipFile(io.BytesIO(response.read()))
     ref = ref[1:] if ref.startswith('v') else ref
     embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, reponame, 'version.py'), 'wb') as f:
+    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
         f.write(embed_version)
 
 
@@ -39,8 +39,8 @@ def get_setup_version(reponame):
         except:
             try: from param import version # Try to get it from param
             except:
-                embed_version(basepath, reponame)
-                version = importlib.import_module(reponame + ".version")
+                embed_version(basepath)
+                version = importlib.import_module("version")
 
     if version is not None:
         return version.Version.setup_version(basepath, reponame, dirty='strip',
@@ -53,6 +53,7 @@ setup_args = dict(
     version=get_setup_version("pkg_params"),
     packages = find_packages(),
     package_data = {'pkg_params': ['.version']},
+    include_package_data = True,
     entry_points = {
         'console_scripts': ['tmpverify=pkg_params.tests:main'],
     },

--- a/examples/pkg_params/tox.ini
+++ b/examples/pkg_params/tox.ini
@@ -4,5 +4,4 @@ envlist = py36
 [testenv]
 passenv = GIT_VERSION
 install_command = pip install --pre --no-index -f {env:SHARED_PACKAGES} {opts} {packages}
-deps = param
 commands = tmpverify pkg_params

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,7 @@ def get_setup_version(reponame):
                 version = importlib.import_module(".version")
 
     if version is not None:
-        return version.Version.setup_version(basepath, reponame, dirty='strip',
-                                             archive_commit="$Format:%h$")
+        return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
         return json.load(open(version_file_path, 'r'))['version_string']
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import importlib
 
 from setuptools import setup, find_packages
 
-def embed_version(basepath, reponame, ref='v0.2.1'):
+def embed_version(basepath, ref='v0.2.1'):
     """
     Autover is purely a build time dependency in all cases (conda and
     pip) except for when you use pip's remote git support [git+url] as
@@ -21,7 +21,7 @@ def embed_version(basepath, reponame, ref='v0.2.1'):
     zf = zipfile.ZipFile(io.BytesIO(response.read()))
     ref = ref[1:] if ref.startswith('v') else ref
     embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, reponame, 'version.py'), 'wb') as f:
+    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
         f.write(embed_version)
 
 
@@ -39,8 +39,8 @@ def get_setup_version(reponame):
         except:
             try: from param import version # Try to get it from param
             except:
-                embed_version(basepath, reponame)
-                version = importlib.import_module(reponame + ".version")
+                embed_version(basepath)
+                version = importlib.import_module(".version")
 
     if version is not None:
         return version.Version.setup_version(basepath, reponame, dirty='strip',
@@ -62,6 +62,7 @@ setup_args = dict(
     url='http://github.com/ioam/autover/',
     packages = find_packages(),
     provides = ["autover"],
+    package_data = {'autover':['.version']},
     include_package_data=True,
     scripts = ["scripts/autover"],
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ def get_setup_version(reponame):
     if version is not None:
         return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
     else:
+        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")
         return json.load(open(version_file_path, 'r'))['version_string']
 
 setup_args = dict(


### PR DESCRIPTION
Various fixes so far:
  * don't embed version.py in the package; store at the top level if it's missing
  * changed default 'dirty' action to 'raise' from 'strip' ('strip' seems like a risky default and is probably only necessary in workflows where .version is being tracked)
  * multiple fixes for problems previously masked by auto downloading & embedding

The changes to the example packages will need careful review.

To do?
  * [ ] simplify setup.py functions in each of the example packages where possible, rather than having exactly the same contents? (E.g. pkg_bundle's setup.py does not need embed_version(), etc...)
  * [x] add a test for 'dirty' (currently nothing happens i.e. if repo is dirty and dirty is set to raise, don't get an error, but should get one)