### PR TITLE
Convert autover script to console script (i.e. support windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,34 @@
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/eiy3sn7hja2nf6dc/branch/master?svg=true)](https://ci.appveyor.com/project/ioam/autover/branch/master)
 
 
-
 Autover provides:
 
   1. Consistent and up-to-date `__version__` strings for Python
      packages; see the [Version
-     class](https://github.com/ioam/autover/blob/master/autover/__init__.py).
+     class](https://github.com/ioam/autover/blob/master/autover/version.py).
 
-  2. A script to import and print the library version and filesystem
-     location for each Python package specified; see the [autover
-     script](https://github.com/ioam/autover/blob/master/scripts/autover).
+  2. Reporting of version and filesystem location for requested Python
+     packages and shell commands.
 
-Authors: Jean-Luc Stevens, Chris Ball and James A. Bednar
+# Versioning
+
+(docs coming soon...)
+
+
+# Reporting
+
+`autover report` can be used to report the versions of specified
+packages. And because the same version of a package may be available
+from many possible different sources (e.g. various conda channels,
+pypi servers, system package managers, built from source, etc), and
+because a package could be installed multiple times on a particular
+system, autover report also includes the filesystem location.
+
+At the commandline, `autover report pkg1 pkg2 cmd1 cmd2 ...` will
+report the version and filesystem location for the specified python
+packages and shell commands.
+
+Reporting may also be done from within python itself, e.g. `import
+autover ; autover.report("numpy","pandas","python","conda")`.
+
+(TODO: e.g. conda is name of command and python package...)

--- a/autover/__init__.py
+++ b/autover/__init__.py
@@ -7,3 +7,4 @@ except:
     import json
     __version__ = json.load(open('.version', 'r'))['version_string']
 
+from .report import report  # noqa: api

--- a/autover/cmd.py
+++ b/autover/cmd.py
@@ -1,11 +1,14 @@
 import argparse
 import inspect
 
+from . import __version__
 from .report import report
 
 
 def main():
     parser = argparse.ArgumentParser(description="Commands relating to versioning")
+    parser.add_argument('--version', action='version', version='%(prog)s '+__version__)
+    
     subparsers = parser.add_subparsers(title='available commands')
 
     report_parser = subparsers.add_parser('report', help=inspect.getdoc(report))

--- a/autover/cmd.py
+++ b/autover/cmd.py
@@ -1,0 +1,21 @@
+import argparse
+import inspect
+
+from .report import report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Commands relating to versioning")
+    subparsers = parser.add_subparsers(title='available commands')
+
+    report_parser = subparsers.add_parser('report', help=inspect.getdoc(report))
+    report_parser.set_defaults(func=report)
+    report_parser.add_argument('packages',metavar='package',type=str,nargs='+',
+                               help='name of package')
+
+    args = parser.parse_args()
+
+    if hasattr(args,'func'):
+        args.func(*args.packages)
+    else:
+        parser.error("must supply command to run")

--- a/autover/report.py
+++ b/autover/report.py
@@ -22,7 +22,20 @@ def report(*packages):
         except (ImportError, ModuleNotFoundError):
             try:
                 # See if there is a command by that name and check its --version if so
-                loc = subprocess.check_output(['which', package]).decode().strip()
+
+                # which not usually available on windows, though it
+                # could be (e.g. running in some kind of bash for
+                # windows, or which binary has been installed,
+                # etc...), so try it first. (And -a to match the list
+                # you get from where; might want to report more than
+                # one in the future if investigating confusion over
+                # what command runs when someone types 'command'.)
+                try:
+                    loc = subprocess.check_output(['which','-a',      package]).decode().splitlines()[0].strip()
+                except:
+                    # .exe in case powershell (otherwise wouldn't need it)
+                    loc = subprocess.check_output(['where.exe',       package]).decode().splitlines()[0].strip()
+
                 out = ""
                 try:
                     out = subprocess.check_output([package, '--version'], stderr=subprocess.STDOUT)

--- a/autover/report.py
+++ b/autover/report.py
@@ -19,7 +19,7 @@ def report(*packages):
             except Exception:
                 pass
 
-        except (ImportError, ModuleNotFoundError):
+        except ImportError:
             try:
                 # See if there is a command by that name and check its --version if so
 

--- a/autover/report.py
+++ b/autover/report.py
@@ -1,14 +1,11 @@
-#!/usr/bin/env python
-# Import and print the library version and filesystem location for each Python package or shell command specified
-#
-# bash usage: $ autover numpy pandas python conda
-# python usage: >>> import autover ; autover("numpy","pandas","python","conda")
-
 from __future__ import print_function
 import os.path, importlib, subprocess
 
-def autover(*packages):
-    """Import and print location and version information for specified Python packages"""
+def report(*packages):
+    """Import and print the library version and filesystem location for
+    each Python package or shell command specified.
+
+    """
     for package in packages:
         loc = "not installed in this environment"
         ver = "unknown"
@@ -21,7 +18,7 @@ def autover(*packages):
                 ver = str(module.__version__)
             except Exception:
                 pass
-        
+
         except (ImportError, ModuleNotFoundError):
             try:
                 # See if there is a command by that name and check its --version if so
@@ -39,10 +36,5 @@ def autover(*packages):
                         break
             except Exception as e:
                 pass
-        
+
         print("{0:30} # {1}".format(package + "=" + ver,loc))
-
-
-if __name__ == "__main__":
-    import sys
-    autover(*(sys.argv[1:]))

--- a/autover/version.py
+++ b/autover/version.py
@@ -427,7 +427,7 @@ class Version(object):
 
     @classmethod
     def get_setup_version(cls, setup_path, reponame, describe=False,
-                          dirty='raise', archive_commit=None):
+                          dirty='report', archive_commit=None):
         """
         Helper for use in setup.py to get the version from the .version file (if available)
         or more up-to-date information from git describe (if available).
@@ -478,7 +478,7 @@ class Version(object):
 
 
     @classmethod
-    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='raise'):
+    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='report'):
         info = {}
         git_describe = None
         try:

--- a/autover/version.py
+++ b/autover/version.py
@@ -427,7 +427,7 @@ class Version(object):
 
     @classmethod
     def get_setup_version(cls, setup_path, reponame, describe=False,
-                          dirty='report', archive_commit=None):
+                          dirty='raise', archive_commit=None):
         """
         Helper for use in setup.py to get the version from the .version file (if available)
         or more up-to-date information from git describe (if available).
@@ -478,7 +478,7 @@ class Version(object):
 
 
     @classmethod
-    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='report'):
+    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='raise'):
         info = {}
         git_describe = None
         try:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,7 @@ test:
     - autover
   commands:
     - nosetests -vv --nologcapture
-    - autover report autover
+    - autover report autover python
 
 about:
   home: {{ sdata['url'] }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,6 +25,7 @@ test:
     - autover
   commands:
     - nosetests -vv --nologcapture
+    - autover report autover
 
 about:
   home: {{ sdata['url'] }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,6 +25,9 @@ test:
     - autover
   commands:
     - nosetests -vv --nologcapture
+    - autover --help
+    - autover --version
+    - autover report --help	   
     - autover report autover python which
 
 about:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,7 @@ test:
     - autover
   commands:
     - nosetests -vv --nologcapture
-    - autover report autover python
+    - autover report autover python which
 
 about:
   home: {{ sdata['url'] }}

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,9 @@ setup_args = dict(
     provides = ["autover"],
     package_data = {'autover':['.version']},
     include_package_data=True,
-    scripts = ["scripts/autover"],
+    entry_points = {
+        'console_scripts': ['autover=autover.cmd:main'],
+    },    
     classifiers = [
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 2.7",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36,py27
 passenv = GIT_VERSION
 deps = nose
 commands = nosetests -vv --nologcapture --with-doctest --with-coverage --cover-package=autover
-           autover report autover python
+           autover report autover python which
 
 [testenv:lint_checks]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36,py27
 passenv = GIT_VERSION
 deps = nose
 commands = nosetests -vv --nologcapture --with-doctest --with-coverage --cover-package=autover
-           autover report autover
+           autover report autover python
 
 [testenv:lint_checks]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,9 @@ envlist = py36,py27
 passenv = GIT_VERSION
 deps = nose
 commands = nosetests -vv --nologcapture --with-doctest --with-coverage --cover-package=autover
+           autover --help
+           autover --version
+           autover report --help           
            autover report autover python which
 
 [testenv:lint_checks]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py36,py27
 passenv = GIT_VERSION
 deps = nose
 commands = nosetests -vv --nologcapture --with-doctest --with-coverage --cover-package=autover
+           autover report autover
 
 [testenv:lint_checks]
 deps = flake8


### PR DESCRIPTION
Change `autover` script to `autover report`.

* Convert autover script to console script (so can run on windows)
* If which doesn't work, try where (again for windows)
* Fix for python 2
* Added --version.

```
$ autover
usage: autover [-h] {report} ...
autover: error: must supply command to run


$ autover --help
usage: autover [-h] {report} ...

Commands relating to versioning

optional arguments:
  -h, --help  show this help message and exit

available commands:
  {report}
    report    Import and print the library version and filesystem location for each Python package or shell command specified.


$ autover report
usage: autover report [-h] package [package ...]
autover report: error: the following arguments are required: package


$ autover report --help
usage: autover report [-h] package [package ...]

positional arguments:
  package     name of package

optional arguments:
  -h, --help  show this help message and exit


$ autover report autover python bash
autover=0.2.1.post11+g4960b3e  # /Users/cball/code/ioam/autover3/autover
python=3.6.0                   # /Users/cball/anaconda3/bin/python
bash=3.2.57(1)-release         # /bin/bash


$ python -c "import autover, numpy; autover.report('autover','python','bash')"
autover=0.2.1.post13+gc6ac374  # /Users/cball/code/ioam/autover3/autover
python=3.6.0                   # /Users/cball/anaconda3/bin/python
bash=3.2.57(1)-release         # /bin/bash
```

Sure you'll want to reorganize/rename, but it's a start. E.g. having subcommands is kind of left over from when there was going to be an autover command to run as part of the versioning workflow.

Note: when considering the organization, we could bear in mind there may be other commands and/or options we should add, including maybe:

* Option to report info about all imported packages? Probably not reporting standard library things by default (i.e. not like the below):

```
$ python -c 'import sys,autover,numpy ; autover.report(*sorted({name.split(".")[0] for name,mod in sys.modules.items() if hasattr(mod,"__file__")}))'
__future__=unknown             # /Users/cball/anaconda3/lib/python3.6
_bisect=unknown                # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_blake2=unknown                # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_bootlocale=unknown            # /Users/cball/anaconda3/lib/python3.6
_bz2=unknown                   # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_collections_abc=unknown       # /Users/cball/anaconda3/lib/python3.6
_compat_pickle=unknown         # /Users/cball/anaconda3/lib/python3.6
_compression=unknown           # /Users/cball/anaconda3/lib/python3.6
_ctypes=1.1.0                  # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_datetime=unknown              # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_frozen_importlib=unknown      # /Users/cball/anaconda3/lib/python3.6/importlib
_frozen_importlib_external=unknown # /Users/cball/anaconda3/lib/python3.6/importlib
_hashlib=unknown               # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_heapq=unknown                 # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_json=unknown                  # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_lzma=unknown                  # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_osx_support=unknown           # /Users/cball/anaconda3/lib/python3.6
_pickle=unknown                # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_posixsubprocess=unknown       # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_random=unknown                # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_sha3=unknown                  # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_sitebuiltins=unknown          # /Users/cball/anaconda3/lib/python3.6
_struct=unknown                # /Users/cball/anaconda3/lib/python3.6/lib-dynload
_sysconfigdata_m_darwin_darwin=unknown # /Users/cball/anaconda3/lib/python3.6
_weakrefset=unknown            # /Users/cball/anaconda3/lib/python3.6
abc=unknown                    # /Users/cball/anaconda3/lib/python3.6
argparse=1.1                   # /Users/cball/anaconda3/lib/python3.6
autover=0.2.1.post13+gc6ac374  # /Users/cball/code/ioam/autover3/autover
bisect=unknown                 # /Users/cball/anaconda3/lib/python3.6
bz2=unknown                    # /Users/cball/anaconda3/lib/python3.6
codecs=unknown                 # /Users/cball/anaconda3/lib/python3.6
collections=unknown            # /Users/cball/anaconda3/lib/python3.6/collections
contextlib=unknown             # /Users/cball/anaconda3/lib/python3.6
copy=unknown                   # /Users/cball/anaconda3/lib/python3.6
copyreg=unknown                # /Users/cball/anaconda3/lib/python3.6
ctypes=1.1.0                   # /Users/cball/anaconda3/lib/python3.6/ctypes
datetime=unknown               # /Users/cball/anaconda3/lib/python3.6
difflib=unknown                # /Users/cball/anaconda3/lib/python3.6
encodings=unknown              # /Users/cball/anaconda3/lib/python3.6/encodings
enum=unknown                   # /Users/cball/anaconda3/lib/python3.6
fnmatch=unknown                # /Users/cball/anaconda3/lib/python3.6
functools=unknown              # /Users/cball/anaconda3/lib/python3.6
genericpath=unknown            # /Users/cball/anaconda3/lib/python3.6
gettext=unknown                # /Users/cball/anaconda3/lib/python3.6
grp=unknown                    # /Users/cball/anaconda3/lib/python3.6/lib-dynload
hashlib=unknown                # /Users/cball/anaconda3/lib/python3.6
heapq=unknown                  # /Users/cball/anaconda3/lib/python3.6
importlib=unknown              # /Users/cball/anaconda3/lib/python3.6/importlib
io=unknown                     # /Users/cball/anaconda3/lib/python3.6
json=2.0.9                     # /Users/cball/anaconda3/lib/python3.6/json
keyword=unknown                # /Users/cball/anaconda3/lib/python3.6
linecache=unknown              # /Users/cball/anaconda3/lib/python3.6
locale=unknown                 # /Users/cball/anaconda3/lib/python3.6
logging=0.5.1.2                # /Users/cball/anaconda3/lib/python3.6/logging
lzma=unknown                   # /Users/cball/anaconda3/lib/python3.6
math=unknown                   # /Users/cball/anaconda3/lib/python3.6/lib-dynload
mtrand=unknown                 # /Users/cball/anaconda3/lib/python3.6/site-packages/numpy/random
ntpath=unknown                 # /Users/cball/anaconda3/lib/python3.6
numbers=unknown                # /Users/cball/anaconda3/lib/python3.6
numpy=1.12.1                   # /Users/cball/anaconda3/lib/python3.6/site-packages/numpy
operator=unknown               # /Users/cball/anaconda3/lib/python3.6
os=unknown                     # /Users/cball/anaconda3/lib/python3.6
pathlib=unknown                # /Users/cball/anaconda3/lib/python3.6
pickle=unknown                 # /Users/cball/anaconda3/lib/python3.6
posixpath=unknown              # /Users/cball/anaconda3/lib/python3.6
pprint=unknown                 # /Users/cball/anaconda3/lib/python3.6
random=unknown                 # /Users/cball/anaconda3/lib/python3.6
re=2.2.1                       # /Users/cball/anaconda3/lib/python3.6
reprlib=unknown                # /Users/cball/anaconda3/lib/python3.6
select=unknown                 # /Users/cball/anaconda3/lib/python3.6/lib-dynload
selectors=unknown              # /Users/cball/anaconda3/lib/python3.6
shutil=unknown                 # /Users/cball/anaconda3/lib/python3.6
signal=unknown                 # /Users/cball/anaconda3/lib/python3.6
site=unknown                   # /Users/cball/anaconda3/lib/python3.6
sre_compile=unknown            # /Users/cball/anaconda3/lib/python3.6
sre_constants=unknown          # /Users/cball/anaconda3/lib/python3.6
sre_parse=unknown              # /Users/cball/anaconda3/lib/python3.6
stat=unknown                   # /Users/cball/anaconda3/lib/python3.6
string=unknown                 # /Users/cball/anaconda3/lib/python3.6
struct=unknown                 # /Users/cball/anaconda3/lib/python3.6
subprocess=unknown             # /Users/cball/anaconda3/lib/python3.6
sysconfig=unknown              # /Users/cball/anaconda3/lib/python3.6
tarfile=unknown                # /Users/cball/anaconda3/lib/python3.6
tempfile=unknown               # /Users/cball/anaconda3/lib/python3.6
textwrap=unknown               # /Users/cball/anaconda3/lib/python3.6
threading=unknown              # /Users/cball/anaconda3/lib/python3.6
token=unknown                  # /Users/cball/anaconda3/lib/python3.6
tokenize=unknown               # /Users/cball/anaconda3/lib/python3.6
traceback=unknown              # /Users/cball/anaconda3/lib/python3.6
types=unknown                  # /Users/cball/anaconda3/lib/python3.6
unittest=unknown               # /Users/cball/anaconda3/lib/python3.6/unittest
urllib=unknown                 # /Users/cball/anaconda3/lib/python3.6/urllib
warnings=unknown               # /Users/cball/anaconda3/lib/python3.6
weakref=unknown                # /Users/cball/anaconda3/lib/python3.6
```

* Option to only report commands, or only packages? I'm not sure how I feel about confusion between e.g. `autover report conda` returning info about the python conda library, or about the conda command.

-----

Maybe not for this PR, but I'm not completely sure which/where will necessarily report the same thing as what would actually run if you were to type in the command at an interactive shell.

```
$ which conda
/Users/cball/anaconda3/bin/conda

$ type conda
conda is a function
conda () 
{ 
    if [ "$#" -ge 1 ]; then
[...]

$ command -v conda
conda
```

```
$ which python
/Users/cball/anaconda3/bin/python

$ type python
python is hashed (/Users/cball/anaconda3/bin/python)
$ hash -r
$ type python
python is /Users/cball/anaconda3/bin/python

$ command -v python
/Users/cball/anaconda3/bin/python
```

The right way of doing it is beyond my knowledge, but I know I've been caught out many times by not running the conda I thought I was running.
