### PR TITLE
Changed default policy for dirty repositories to 'report'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -306,7 +306,7 @@ jobs:
       script: doit $EXTRA check_dirty_package_name
 
     # test on autover itself
-    - <<: conda_default
+    - <<: *conda_default
       stage: test
       env: DESC="check dirty conda"
       install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,19 +202,6 @@ jobs:
       script:
         - doit $EXTRA verify_installed_version --example=$MODULE
 
-##############################
-
-# test that -dirty appears in package name for dirty repo
-
-    - <<: *example_tests
-      python: 3.6
-      env:
-        - DESC="check dirty"
-        - MODULE=pkg_bundle
-        - EXTRA="--dir=/tmp/123"
-      install: true
-      script:
-        - doit $EXTRA check_dirty_package_name
 
 ##############################
 
@@ -303,3 +290,24 @@ jobs:
         - doit $EXTRA git_init
       script:
         - doit $EXTRA build_conda_package -c pyviz/label/dev
+
+
+##############################
+
+# test that -dirty appears in package name for dirty repo
+
+    - <<: *example_tests
+      python: 3.6
+      env:
+        - DESC="check dirty pip"
+        - MODULE=pkg_bundle
+        - EXTRA="--dir=/tmp/123"
+      install: true
+      script: doit $EXTRA check_dirty_package_name
+
+    # test on autover itself
+    - <<: conda_default
+      stage: test
+      env: DESC="check dirty conda"
+      install: true
+      script: doit $EXTRA check_dirty_fails_conda_package

--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,7 @@ jobs:
 
 ##############################
 
-# test that dirty detection works
+# test that -dirty appears in package name for dirty repo
 
     - <<: *example_tests
       python: 3.6
@@ -214,7 +214,7 @@ jobs:
         - EXTRA="--dir=/tmp/123"
       install: true
       script:
-        - doit $EXTRA check_dirty_detection
+        - doit $EXTRA check_dirty_package_name
 
 ##############################
 

--- a/autover/version.py
+++ b/autover/version.py
@@ -427,7 +427,7 @@ class Version(object):
 
     @classmethod
     def get_setup_version(cls, setup_path, reponame, describe=False,
-                          dirty='raise', archive_commit=None):
+                          dirty='report', archive_commit=None):
         """
         Helper for use in setup.py to get the version from the .version file (if available)
         or more up-to-date information from git describe (if available).
@@ -478,7 +478,7 @@ class Version(object):
 
 
     @classmethod
-    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='raise'):
+    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='report'):
         info = {}
         git_describe = None
         try:

--- a/dodo.py
+++ b/dodo.py
@@ -92,12 +92,16 @@ def task_check_dirty_package_name():
         'actions':[
             'echo "#dirty" >> setup.py',
             'git describe --dirty --long',
-
-            # for pip
             'python setup.py sdist',
             'python -c "import os,glob; assert len(glob.glob(\'dist/*+g*.dirty.tar.gz\'))==1, os.listdir(\'dist\')"',
+        ]}
 
-            # for conda
+def task_check_dirty_fails_conda_package():
+    # TODO: test should be less bash
+    return {
+        'actions':[
+            'echo "#dirty" >> setup.py',
+            'git describe --dirty --long',
             '! conda build conda.recipe > conda-dirty-check 2>&1',
             'grep "Error: bad character \'-\' in package/version" conda-dirty-check'
         ],

--- a/dodo.py
+++ b/dodo.py
@@ -86,16 +86,21 @@ def task_original_script():
         ]
     }
 
-def task_check_dirty_detection():
+def task_check_dirty_package_name():
     # TODO: test should be less bash
     return {
         'actions':[
             'echo "#dirty" >> setup.py',
             'git describe --dirty --long',
-            '! python setup.py sdist > test-dirty-check 2>&1',
-            'grep "AssertionError: Repository is in a dirty state." test-dirty-check'
+
+            # for pip
+            'python setup.py sdist',
+            'python -c "import os,glob; assert len(glob.glob(\'dist/*+g*.dirty.tar.gz\'))==1, os.listdir(\'dist\')"',
+
+            # for conda
+            '! conda build conda.recipe > conda-dirty-check 2>&1',
+            'grep "Error: bad character \'-\' in package/version" conda-dirty-check'
         ],
         'teardown':[
-            'cat test-dirty-check'
+            'python -c "print(open(\'conda-dirty-check\').read())"'
         ]}
-

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -427,7 +427,7 @@ class Version(object):
 
     @classmethod
     def get_setup_version(cls, setup_path, reponame, describe=False,
-                          dirty='raise', archive_commit=None):
+                          dirty='report', archive_commit=None):
         """
         Helper for use in setup.py to get the version from the .version file (if available)
         or more up-to-date information from git describe (if available).
@@ -478,7 +478,7 @@ class Version(object):
 
 
     @classmethod
-    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='raise'):
+    def setup_version(cls, setup_path, reponame, archive_commit=None, dirty='report'):
         info = {}
         git_describe = None
         try:


### PR DESCRIPTION
This is a friendlier default e.g for ``python setup.py develop``.