### PR TITLE
Provide get_setup_version function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,9 +130,6 @@ jobs:
     - <<: *pkg_depend
       python: 2.7
 
-    - <<: *pkg_depend_autodl
-      python: 2.7
-
     - <<: *pkg_depend_pipgit
       python: 2.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,7 +212,7 @@ jobs:
       script:
         - doit build_conda_package
         # autover required for conda-build *before* build time (for templated version)
-        - conda install --use-local autover
+        - conda install -y --use-local autover
         - doit $DIR_EXAMPLE build_conda_package
 
     - <<: *conda_example_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,6 @@ jobs:
       install:
         # build autover package so it's available for pip...
         - python setup.py bdist_wheel
-        - ls -l ${TRAVIS_BUILD_DIR}/dist
         # ...and install from local dir only
         - pip install -f file://${TRAVIS_BUILD_DIR}/dist --pre --no-index git+file:///tmp/123
       script: doit $DIR_EXAMPLE verify_installed_version --example=$EXAMPLE --example-pkgname=$EXAMPLE_PKGNAME
@@ -212,6 +211,8 @@ jobs:
       env: EXAMPLE=pkg_depend
       script:
         - doit build_conda_package
+        # autover required for conda-build *before* build time (for templated version)
+        - conda install --use-local autover
         - doit $DIR_EXAMPLE build_conda_package
 
     - <<: *conda_example_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ stages:
   - lint
   - test
   - example
-  - example_autodl
   - example_pipgit
   - conda_example
   - check_dirty
@@ -79,13 +78,6 @@ jobs:
         - python setup.py bdist_wheel
       script:
         - doit $DIR_EXAMPLE original_script --example=$EXAMPLE --example-pkgname=$EXAMPLE_PKGNAME
-
-    - &pkg_depend_autodl
-      <<: *pkg_depend
-      stage: example_autodl
-      env: EXAMPLE=pkg_depend
-      # build package so it's available for pip
-      install: python setup.py bdist_wheel
 
     - &pkg_depend_pipgit
       <<: *pkg_depend

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ jobs:
             pip install "doit<0.30";
           fi
         - pip install "pyct <0.2.1" tox
+        # until https://github.com/tox-dev/tox/issues/850 resolved (would also be resolved by switching to pyctdev)
+        - pip install --upgrade --force-reinstall git+https://github.com/ceball/tox.git@pep-518
         - doit $DIR_EXAMPLE copy_example_project --example=$EXAMPLE
         - doit $DIR_EXAMPLE git_init
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,12 @@ jobs:
       <<: *pkg_depend
       stage: example_pipgit
       env: EXAMPLE=pkg_depend
-      install: pip install git+file:///tmp/123
+      install:
+        # build autover package so it's available for pip...
+        - python setup.py bdist_wheel
+        - ls -l ${TRAVIS_BUILD_DIR}/dist
+        # ...and install from local dir only
+        - pip install -f file://${TRAVIS_BUILD_DIR}/dist --pre --no-index git+file:///tmp/123
       script: doit $DIR_EXAMPLE verify_installed_version --example=$EXAMPLE --example-pkgname=$EXAMPLE_PKGNAME
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ jobs:
       env: EXAMPLE=pkg_depend
       python: 3.6
       before_install:
+        # need pip>=10
+        - pip install --upgrade pip
         - mkdir /tmp/123
         - if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then
             pip install "doit<0.30";

--- a/autover/version.py
+++ b/autover/version.py
@@ -553,8 +553,17 @@ def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
 def get_setup_version2():
     """As get_setup_version(), but configure via setup.cfg.
 
-    If the repository name is different from the package name, specify `reponame`, e.g.
+    If your project uses setup.cfg to configure setuptools, and hence has
+    at least a "name" key in the [metadata] section, you can
+    set the version as follows:
+    ```
+    [metadata]
+    name = mypackage
+    version = attr: autover.version.get_setup_version2
+    ```
 
+    If the repository name is different from the package name, specify
+    `reponame` as a [tool:autover] option:
     ```
     [tool:autover]
     reponame = mypackage

--- a/autover/version.py
+++ b/autover/version.py
@@ -551,7 +551,7 @@ def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
 
 
 def get_setup_version2():
-    """As get_setup_version(), but configure via [tool:autover] in setup.cfg.
+    """As get_setup_version(), but configure via setup.cfg.
 
     If the repository name is different from the package name, specify `reponame`, e.g.
 
@@ -572,9 +572,9 @@ def get_setup_version2():
     [tool:autover.configparser_workaround.archive_commit=$Format:%h$]
     ```
 
-    The above being a section heading rather than just a key is that
-    setuptools requires % to be escaped with %, or it can't parse
-    setup.cfg...but then git export-subst would not work.
+    The above being a section heading rather than just a key is
+    because setuptools requires % to be escaped with %, or it can't
+    parse setup.cfg...but then git export-subst would not work.
 
     """
     try:

--- a/autover/version.py
+++ b/autover/version.py
@@ -551,15 +551,14 @@ def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
 
 
 def get_setup_version2():
-    """As get_setup_version(), but configure via setup.cfg:
+    """As get_setup_version(), but configure via [tool:autover] in setup.cfg.
+
+    If the repository name is different from the package name, specify `reponame`, e.g.
 
     ```
     [tool:autover]
-    reponame = x
+    reponame = mypackage
     ```
-
-    Can also specify an optional `pkgname` if different from
-    `reponame`.
 
     To ensure git information is included in a git archive, add
     setup.cfg to .gitattributes (in addition to __init__):
@@ -586,8 +585,8 @@ def get_setup_version2():
     cfg = "setup.cfg"
     config = configparser.ConfigParser()
     config.read(cfg)
-    reponame = config.get('tool:autover','reponame')
-    pkgname = config.get('tool:autover','pkgname',vars={'pkgname':reponame})
+    pkgname = config.get('metadata','name')
+    reponame = config.get('tool:autover','reponame',vars={'reponame':pkgname})
 
     ###
     # hack archive_commit into section heading; see docstring
@@ -597,4 +596,4 @@ def get_setup_version2():
         if section.startswith(archive_commit_key):
             archive_commit = re.match(".*=\s*(\S*)\s*",section).group(1)
     ###
-    return get_setup_version(cfg,reponame,pkgname=pkgname,archive_commit=archive_commit)
+    return get_setup_version(cfg,reponame=reponame,pkgname=pkgname,archive_commit=archive_commit)

--- a/autover/version.py
+++ b/autover/version.py
@@ -522,3 +522,79 @@ class Version(object):
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']
+
+
+
+# TODO: should these be available via Version instead?
+
+def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
+    """Helper for use in setup.py to get the current version from either
+    git describe or the .version file (if available).
+
+    Set pkgname to the package name if it is different from the
+    repository name.
+
+    To ensure git information is included in a git archive, add
+    setup.py to .gitattributes (in addition to __init__):
+    ```
+    __init__.py export-subst
+    setup.py export-subst
+    ```
+    Then supply "$Format:%h$" for archive_commit.
+
+    """
+    import warnings
+    pkgname = reponame if pkgname is None else pkgname
+    if archive_commit is None:
+        warnings.warn("No archive commit available; git archives will not contain version information")
+    return Version.setup_version(os.path.dirname(os.path.abspath(location)),reponame,pkgname=pkgname,archive_commit=archive_commit)
+
+
+def get_setup_version2():
+    """As get_setup_version(), but configure via setup.cfg:
+
+    ```
+    [tool:autover]
+    reponame = x
+    ```
+
+    Can also specify an optional `pkgname` if different from
+    `reponame`.
+
+    To ensure git information is included in a git archive, add
+    setup.cfg to .gitattributes (in addition to __init__):
+    ```
+    __init__.py export-subst
+    setup.cfg export-subst
+    ```
+
+    Then add the following to setup.cfg:
+    ```
+    [tool:autover.configparser_workaround.archive_commit=$Format:%h$]
+    ```
+
+    The above being a section heading rather than just a key is that
+    setuptools requires % to be escaped with %, or it can't parse
+    setup.cfg...but then git export-subst would not work.
+
+    """
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser # python2 (also prevents dict-like access)
+    import re
+    cfg = "setup.cfg"
+    config = configparser.ConfigParser()
+    config.read(cfg)
+    reponame = config.get('tool:autover','reponame')
+    pkgname = config.get('tool:autover','pkgname',vars={'pkgname':reponame})
+
+    ###
+    # hack archive_commit into section heading; see docstring
+    archive_commit = None
+    archive_commit_key = 'tool:autover.configparser_workaround.archive_commit'
+    for section in config.sections():
+        if section.startswith(archive_commit_key):
+            archive_commit = re.match(".*=\s*(\S*)\s*",section).group(1)
+    ###
+    return get_setup_version(cfg,reponame,pkgname=pkgname,archive_commit=archive_commit)

--- a/autover/version.py
+++ b/autover/version.py
@@ -525,8 +525,6 @@ class Version(object):
 
 
 
-# TODO: should these be available via Version instead?
-
 def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
     """Helper for use in setup.py to get the current version from either
     git describe or the .version file (if available).

--- a/autover/version.py
+++ b/autover/version.py
@@ -550,7 +550,7 @@ def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
     return Version.setup_version(os.path.dirname(os.path.abspath(location)),reponame,pkgname=pkgname,archive_commit=archive_commit)
 
 
-def get_setup_version2():
+def get_setupcfg_version():
     """As get_setup_version(), but configure via setup.cfg.
 
     If your project uses setup.cfg to configure setuptools, and hence has

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,6 +23,8 @@ test:
     - nose
   imports:
     - autover
+  source_files:
+    - tests
   commands:
     - nosetests -vv --nologcapture
 

--- a/dodo.py
+++ b/dodo.py
@@ -86,7 +86,7 @@ def task_original_script():
 
             # dev install, then...
             # TODO: need prerelease param just now; remove pre & index urls after release
-            action.CmdAction('pip install -f ' + shared_packages + '--pre --index-url=https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple -e .',env=env2),
+            action.CmdAction('pip install -f ' + shared_packages + ' --pre --index-url=https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple -e .',env=env2),
 
             # 2. ...verify in git repo (TODO: could just be "tmpverify %(example)s", I think)
             action.CmdAction(lambda example,example_pkgname: 'python '+ _x(example,example_pkgname)+'/tests/__init__.py '+_x(example,example_pkgname),env=env2),

--- a/dodo.py
+++ b/dodo.py
@@ -71,7 +71,8 @@ def task_verify_installed_version():
 # TODO: split up
 def task_original_script():
     env1 = os.environ.copy()
-    env1["PIP_FIND_LINKS"] = os.path.join(doit.get_initial_workdir(), "dist")
+    shared_packages = os.path.join(doit.get_initial_workdir(), "dist")
+    env1["PIP_FIND_LINKS"] = shared_packages
 
     env2 = os.environ.copy()
     env2['PYTHONPATH'] = os.getcwd() # TODO win
@@ -85,7 +86,7 @@ def task_original_script():
 
             # dev install, then...
             # TODO: need prerelease param just now; remove pre & index urls after release
-            action.CmdAction('pip install --pre --index-url=https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple -e .',env=env2),
+            action.CmdAction('pip install -f ' + shared_packages + ' --pre --index-url=https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple -e .',env=env2),
 
             # 2. ...verify in git repo (TODO: could just be "tmpverify %(example)s", I think)
             action.CmdAction(lambda example,example_pkgname: 'python '+ _x(example,example_pkgname)+'/tests/__init__.py '+_x(example,example_pkgname),env=env2),

--- a/dodo.py
+++ b/dodo.py
@@ -70,9 +70,8 @@ def task_verify_installed_version():
 
 # TODO: split up
 def task_original_script():
-    shared_packages = os.path.join(doit.get_initial_workdir(), "dist")
     env1 = os.environ.copy()
-    env1['SHARED_PACKAGES'] = shared_packages
+    env1["PIP_FIND_LINKS"] = os.path.join(doit.get_initial_workdir(), "dist")
 
     env2 = os.environ.copy()
     env2['PYTHONPATH'] = os.getcwd() # TODO win
@@ -86,7 +85,7 @@ def task_original_script():
 
             # dev install, then...
             # TODO: need prerelease param just now; remove pre & index urls after release
-            action.CmdAction('pip install -f ' + shared_packages + ' --pre --index-url=https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple -e .',env=env2),
+            action.CmdAction('pip install --pre --index-url=https://test.pypi.org/simple/ --extra-index-url=https://pypi.org/simple -e .',env=env2),
 
             # 2. ...verify in git repo (TODO: could just be "tmpverify %(example)s", I think)
             action.CmdAction(lambda example,example_pkgname: 'python '+ _x(example,example_pkgname)+'/tests/__init__.py '+_x(example,example_pkgname),env=env2),

--- a/examples/PkgBundle/setup.py
+++ b/examples/PkgBundle/setup.py
@@ -1,58 +1,11 @@
 from setuptools import setup, find_packages
 
-def embed_version(basepath, ref='v0.2.5'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, os
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    response = urlopen('https://github.com/ioam/autover/archive/{ref}.zip'.format(ref=ref))
-    zf = zipfile.ZipFile(io.BytesIO(response.read()))
-    ref = ref[1:] if ref.startswith('v') else ref
-    embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-        f.write(embed_version)
-
-
-def get_setup_version(reponame, pkgname=None):
-    """
-    Helper to get the current version from either git describe or the
-    .version file (if available). Set pkgname to the package name if it
-    is different from the repository name.
-    """
-    import json, importlib, os
-    pkgname = reponame if pkgname is None else pkgname
-    basepath = os.path.dirname(os.path.abspath(__file__))
-    version_file_path = os.path.join(basepath, reponame, '.version')
-    version = None
-    try: version = importlib.import_module("version") # bundled
-    except:
-        try: from autover import version # available as package
-        except:
-            try: from param import version # available via param
-            except:
-                embed_version(basepath) # download
-                version = importlib.import_module("version")
-
-    if version is not None:
-        return version.Version.setup_version(basepath, reponame, pkgname=pkgname,
-                                             archive_commit="$Format:%h$")
-    else:
-        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")
-        return json.load(open(version_file_path, 'r'))['version_string']
 
 package_name = "pkg_bundle"
 
 setup_args = dict(
     name=package_name,
-    version=get_setup_version("PkgBundle",package_name),
+    version=version.get_setup_version(__file__,"PkgBundle",package_name),
     packages = find_packages(),
     include_package_data=True,    
     entry_points = {

--- a/examples/PkgBundle/setup.py
+++ b/examples/PkgBundle/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, find_packages
 
+from version import get_setup_version
 
 package_name = "pkg_bundle"
 
 setup_args = dict(
     name=package_name,
-    version=version.get_setup_version(__file__,"PkgBundle",package_name),
+    version=get_setup_version(__file__,"PkgBundle",package_name),
     packages = find_packages(),
     include_package_data=True,    
     entry_points = {

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -522,3 +522,87 @@ class Version(object):
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']
+
+
+
+# TODO: should these be available via Version instead?
+
+def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
+    """Helper for use in setup.py to get the current version from either
+    git describe or the .version file (if available).
+
+    Set pkgname to the package name if it is different from the
+    repository name.
+
+    To ensure git information is included in a git archive, add
+    setup.py to .gitattributes (in addition to __init__):
+    ```
+    __init__.py export-subst
+    setup.py export-subst
+    ```
+    Then supply "$Format:%h$" for archive_commit.
+
+    """
+    import warnings
+    pkgname = reponame if pkgname is None else pkgname
+    if archive_commit is None:
+        warnings.warn("No archive commit available; git archives will not contain version information")
+    return Version.setup_version(os.path.dirname(os.path.abspath(location)),reponame,pkgname=pkgname,archive_commit=archive_commit)
+
+
+def get_setupcfg_version():
+    """As get_setup_version(), but configure via setup.cfg.
+
+    If your project uses setup.cfg to configure setuptools, and hence has
+    at least a "name" key in the [metadata] section, you can
+    set the version as follows:
+    ```
+    [metadata]
+    name = mypackage
+    version = attr: autover.version.get_setup_version2
+    ```
+
+    If the repository name is different from the package name, specify
+    `reponame` as a [tool:autover] option:
+    ```
+    [tool:autover]
+    reponame = mypackage
+    ```
+
+    To ensure git information is included in a git archive, add
+    setup.cfg to .gitattributes (in addition to __init__):
+    ```
+    __init__.py export-subst
+    setup.cfg export-subst
+    ```
+
+    Then add the following to setup.cfg:
+    ```
+    [tool:autover.configparser_workaround.archive_commit=$Format:%h$]
+    ```
+
+    The above being a section heading rather than just a key is
+    because setuptools requires % to be escaped with %, or it can't
+    parse setup.cfg...but then git export-subst would not work.
+
+    """
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser # python2 (also prevents dict-like access)
+    import re
+    cfg = "setup.cfg"
+    config = configparser.ConfigParser()
+    config.read(cfg)
+    pkgname = config.get('metadata','name')
+    reponame = config.get('tool:autover','reponame',vars={'reponame':pkgname})
+
+    ###
+    # hack archive_commit into section heading; see docstring
+    archive_commit = None
+    archive_commit_key = 'tool:autover.configparser_workaround.archive_commit'
+    for section in config.sections():
+        if section.startswith(archive_commit_key):
+            archive_commit = re.match(".*=\s*(\S*)\s*",section).group(1)
+    ###
+    return get_setup_version(cfg,reponame=reponame,pkgname=pkgname,archive_commit=archive_commit)

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -525,8 +525,6 @@ class Version(object):
 
 
 
-# TODO: should these be available via Version instead?
-
 def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
     """Helper for use in setup.py to get the current version from either
     git describe or the .version file (if available).

--- a/examples/pkg_bundle/setup.py
+++ b/examples/pkg_bundle/setup.py
@@ -1,57 +1,10 @@
 from setuptools import setup, find_packages
 
-def embed_version(basepath, ref='v0.2.5'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, os
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    response = urlopen('https://github.com/ioam/autover/archive/{ref}.zip'.format(ref=ref))
-    zf = zipfile.ZipFile(io.BytesIO(response.read()))
-    ref = ref[1:] if ref.startswith('v') else ref
-    embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-        f.write(embed_version)
-
-
-def get_setup_version(reponame, pkgname=None):
-    """
-    Helper to get the current version from either git describe or the
-    .version file (if available). Set pkgname to the package name if it
-    is different from the repository name.
-    """
-    import json, importlib, os
-    pkgname = reponame if pkgname is None else pkgname
-    basepath = os.path.dirname(os.path.abspath(__file__))
-    version_file_path = os.path.join(basepath, pkgname, '.version')
-    version = None
-    try: version = importlib.import_module("version") # bundled
-    except:
-        try: from autover import version # available as package
-        except:
-            try: from param import version # available via param
-            except:
-                embed_version(basepath) # download
-                version = importlib.import_module("version")
-
-    if version is not None:
-        return version.Version.setup_version(basepath, reponame, pkgname=pkgname,
-                                             archive_commit="$Format:%h$")
-    else:
-        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")
-        return json.load(open(version_file_path, 'r'))['version_string']
-
+from version import get_setup_version
 
 setup_args = dict(
     name='pkg_bundle',
-    version=get_setup_version("pkg_bundle"),
+    version=get_setup_version(__file__,"pkg_bundle",archive_commit="$Format:%h$"),
     packages = find_packages(),
     include_package_data=True,    
     entry_points = {

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -522,3 +522,87 @@ class Version(object):
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']
+
+
+
+# TODO: should these be available via Version instead?
+
+def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
+    """Helper for use in setup.py to get the current version from either
+    git describe or the .version file (if available).
+
+    Set pkgname to the package name if it is different from the
+    repository name.
+
+    To ensure git information is included in a git archive, add
+    setup.py to .gitattributes (in addition to __init__):
+    ```
+    __init__.py export-subst
+    setup.py export-subst
+    ```
+    Then supply "$Format:%h$" for archive_commit.
+
+    """
+    import warnings
+    pkgname = reponame if pkgname is None else pkgname
+    if archive_commit is None:
+        warnings.warn("No archive commit available; git archives will not contain version information")
+    return Version.setup_version(os.path.dirname(os.path.abspath(location)),reponame,pkgname=pkgname,archive_commit=archive_commit)
+
+
+def get_setupcfg_version():
+    """As get_setup_version(), but configure via setup.cfg.
+
+    If your project uses setup.cfg to configure setuptools, and hence has
+    at least a "name" key in the [metadata] section, you can
+    set the version as follows:
+    ```
+    [metadata]
+    name = mypackage
+    version = attr: autover.version.get_setup_version2
+    ```
+
+    If the repository name is different from the package name, specify
+    `reponame` as a [tool:autover] option:
+    ```
+    [tool:autover]
+    reponame = mypackage
+    ```
+
+    To ensure git information is included in a git archive, add
+    setup.cfg to .gitattributes (in addition to __init__):
+    ```
+    __init__.py export-subst
+    setup.cfg export-subst
+    ```
+
+    Then add the following to setup.cfg:
+    ```
+    [tool:autover.configparser_workaround.archive_commit=$Format:%h$]
+    ```
+
+    The above being a section heading rather than just a key is
+    because setuptools requires % to be escaped with %, or it can't
+    parse setup.cfg...but then git export-subst would not work.
+
+    """
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser # python2 (also prevents dict-like access)
+    import re
+    cfg = "setup.cfg"
+    config = configparser.ConfigParser()
+    config.read(cfg)
+    pkgname = config.get('metadata','name')
+    reponame = config.get('tool:autover','reponame',vars={'reponame':pkgname})
+
+    ###
+    # hack archive_commit into section heading; see docstring
+    archive_commit = None
+    archive_commit_key = 'tool:autover.configparser_workaround.archive_commit'
+    for section in config.sections():
+        if section.startswith(archive_commit_key):
+            archive_commit = re.match(".*=\s*(\S*)\s*",section).group(1)
+    ###
+    return get_setup_version(cfg,reponame=reponame,pkgname=pkgname,archive_commit=archive_commit)

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -525,8 +525,6 @@ class Version(object):
 
 
 
-# TODO: should these be available via Version instead?
-
 def get_setup_version(location, reponame, pkgname=None, archive_commit=None):
     """Helper for use in setup.py to get the current version from either
     git describe or the .version file (if available).

--- a/examples/pkg_depend/conda.recipe/meta.yaml
+++ b/examples/pkg_depend/conda.recipe/meta.yaml
@@ -15,14 +15,9 @@ requirements:
   build:
     - python
     - setuptools
-    - autover
+    - autover # TODO: specify min version
   run:
     - python
-    # autover is listed in setup.py install_requires; when the console
-    # script (tmpverify) is run, python will attempt to install
-    # autover if autover's not already installed. Therefore, make
-    # runtime dependency explicit here. (Alternative would be to add
-    # autover under 'test requires'?)
     - autover
 
 test:

--- a/examples/pkg_depend/pkg_depend/__init__.py
+++ b/examples/pkg_depend/pkg_depend/__init__.py
@@ -1,6 +1,2 @@
-try:
-    from autover.version import Version
-    __version__ = str(Version(fpath=__file__,archive_commit="$Format:%h$",reponame="pkg_depend"))
-except:
-    import os, json
-    __version__ = json.load(open(os.path.join(os.path.dirname(__file__),'.version'),'r'))['version_string']
+from autover.version import Version
+__version__ = str(Version(fpath=__file__,archive_commit="$Format:%h$",reponame="pkg_depend"))

--- a/examples/pkg_depend/pyproject.toml
+++ b/examples/pkg_depend/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+# todo: specify minimum autover
+requires = [
+    "autover"
+]

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+import autover.version
+
 setup_args = dict(
     name='pkg_depend',
     version=autover.version.get_setup_version(__file__,"pkg_depend",archive_commit="$Format:%h$"),

--- a/examples/pkg_depend/setup.py
+++ b/examples/pkg_depend/setup.py
@@ -1,58 +1,8 @@
 from setuptools import setup, find_packages
 
-
-def embed_version(basepath, ref='v0.2.5'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, os
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    response = urlopen('https://github.com/ioam/autover/archive/{ref}.zip'.format(ref=ref))
-    zf = zipfile.ZipFile(io.BytesIO(response.read()))
-    ref = ref[1:] if ref.startswith('v') else ref
-    embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-        f.write(embed_version)
-
-
-def get_setup_version(reponame, pkgname=None):
-    """
-    Helper to get the current version from either git describe or the
-    .version file (if available). Set pkgname to the package name if it
-    is different from the repository name.
-    """
-    import json, importlib, os
-    pkgname = reponame if pkgname is None else pkgname
-    basepath = os.path.dirname(os.path.abspath(__file__))
-    version_file_path = os.path.join(basepath, reponame, '.version')
-    version = None
-    try: version = importlib.import_module("version") # bundled
-    except:
-        try: from autover import version # available as package
-        except:
-            try: from param import version # available via param
-            except:
-                embed_version(basepath) # download
-                version = importlib.import_module("version")
-
-    if version is not None:
-        return version.Version.setup_version(basepath, reponame, pkgname=pkgname,
-                                             archive_commit="$Format:%h$")
-    else:
-        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")
-        return json.load(open(version_file_path, 'r'))['version_string']
-
-
 setup_args = dict(
     name='pkg_depend',
-    version=get_setup_version("pkg_depend"),
+    version=autover.version.get_setup_version(__file__,"pkg_depend",archive_commit="$Format:%h$"),
     packages = find_packages(),
     include_package_data = True,
     entry_points = {

--- a/examples/pkg_depend/tox.ini
+++ b/examples/pkg_depend/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py36
+build = wheel
 
 [testenv]
 passenv = GIT_VERSION

--- a/examples/pkg_depend/tox.ini
+++ b/examples/pkg_depend/tox.ini
@@ -4,9 +4,6 @@ build = wheel
 
 [testenv]
 passenv = GIT_VERSION
-# sitepackages until tox via pip supports build deps
-# (https://github.com/tox-dev/tox/issues/850), or until we use pyctdev
-# (autover currently using early prototype...)
-sitepackages = True
-install_command = pip install --pre --no-index -f {env:SHARED_PACKAGES} {opts} {packages}
+# get local only dependencies only (i.e. get the autover we have built)
+install_command = pip install --pre --no-index {opts} {packages}
 commands = tmpverify pkg_depend

--- a/examples/pkg_depend/tox.ini
+++ b/examples/pkg_depend/tox.ini
@@ -3,5 +3,9 @@ envlist = py36
 
 [testenv]
 passenv = GIT_VERSION
+# sitepackages until tox via pip supports build deps
+# (https://github.com/tox-dev/tox/issues/850), or until we use pyctdev
+# (autover currently using early prototype...)
+sitepackages = True
 install_command = pip install --pre --no-index -f {env:SHARED_PACKAGES} {opts} {packages}
 commands = tmpverify pkg_depend

--- a/examples/pkg_json_fallback/setup.py
+++ b/examples/pkg_json_fallback/setup.py
@@ -1,25 +1,5 @@
 from setuptools import setup, find_packages
 
-def embed_version(basepath, ref='v0.2.5'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, os
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    response = urlopen('https://github.com/ioam/autover/archive/{ref}.zip'.format(ref=ref))
-    zf = zipfile.ZipFile(io.BytesIO(response.read()))
-    ref = ref[1:] if ref.startswith('v') else ref
-    embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-        f.write(embed_version)
-
 
 def get_setup_version(reponame):
     """

--- a/examples/pkg_params/setup.py
+++ b/examples/pkg_params/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+# TODO: update to use param.version.get_setup_version when param is updated
+
 def embed_version(basepath, ref='v0.2.5'):
     """
     Autover is purely a build time dependency in all cases (conda and

--- a/setup.py
+++ b/setup.py
@@ -2,57 +2,12 @@ import os
 
 from setuptools import setup, find_packages
 
-def embed_version(basepath, ref='v0.2.5'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, os
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    response = urlopen('https://github.com/ioam/autover/archive/{ref}.zip'.format(ref=ref))
-    zf = zipfile.ZipFile(io.BytesIO(response.read()))
-    ref = ref[1:] if ref.startswith('v') else ref
-    embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-    with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-        f.write(embed_version)
-
-
-def get_setup_version(reponame, pkgname=None):
-    """
-    Helper to get the current version from either git describe or the
-    .version file (if available). Set pkgname to the package name if it
-    is different from the repository name.
-    """
-    import json, importlib, os
-    pkgname = reponame if pkgname is None else pkgname
-    basepath = os.path.dirname(os.path.abspath(__file__))
-    version_file_path = os.path.join(basepath, pkgname, '.version')
-    version = None
-    try: version = importlib.import_module("version") # bundled
-    except:
-        try: from autover import version # available as package
-        except:
-            try: from param import version # available via param
-            except:
-                embed_version(basepath) # download
-                version = importlib.import_module("version")
-
-    if version is not None:
-        return version.Version.setup_version(basepath, reponame, pkgname=pkgname,
-                                             archive_commit="$Format:%h$")
-    else:
-        print("WARNING: autover unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should refer to autover's documentation to bundle autover or add it as a dependency.")
-        return json.load(open(version_file_path, 'r'))['version_string']
+# Versioning autover depends on autover.
+from autover.version import get_setup_version
 
 setup_args = dict(
     name='autover',
-    version=get_setup_version("autover"),
+    version=get_setup_version(__file__, "autover", archive_commit="$Format:%h$"),
     description='Autover provides consistent and up-to-date `__version__` strings for Python packages.',
     long_description=open('README.rst').read() if os.path.isfile('README.rst') else 'Consult README.rst',
     author= "IOAM",


### PR DESCRIPTION
Currently, autover requires that projects duplicate the get_setup_version() and embed_version() functions in their own setup.py files. Before pip 10 arrived, pip did not support "build time" dependencies, so having the functions in each project's setup.py and including a way to download version.py if it wasn't already available made sense. But now with pip 10, projects can declare that the appropriate version of either autover or param must be available before running setup.py. This PR takes advantage of build time dependencies to move get_setup_version() into version.py itself, and to eliminate embed_version().

In any case, setup.py dependencies won't affect users installing via wheel or conda packages (i.e. this change won't affect the majority of end users). Packagers and users installing from git source will be affected, but pip>=10 and conda build both support declaring build time dependencies. But to avoid confusion for users installing from git source who do not yet have pip 10, projects could include something like the following in their setup.py:
```
try:
    import param
    assert param.version >= whatever
except:
    raise "Building xyz requires param >= whatever. Please upgrade to pip>=10 and try again. Alternatively, install the build dependencies manually first (e.g. `pip install --upgrade "param>=whatever"` or `conda install -c pyviz "param>=whatever"`)')
```

Note that I have not updated tests etc, but will go on to do that if the idea of this PR is accepted in principle.

The alternative approach of bundling version.py in a project will also be simplified by these changes, because projects will be able to import the get_setup_version function from the bundled file, rather than having to define it in setup.py.

I have also added get_setup_version2(), which is the same as get_setup_version(), except that it's configured via setup.cfg. This allows the following kind of thing in setup.cfg:

```
[metadata]
name = xyz
version = attr: param.version.get_setup_version2
...
```

as an alternative to the following kind of thing in setup.py:

```
setup_args = dict(
    name='xyz',
    version=param.version.get_setup_version(__file__, "xyz", ...),
    ...
```

There are some to-dos:
  * should get_setup_version fns be available via Version rather than as standalone fns?
  * rename the get_setup_version fns?