### PR TITLE
Fix repository name matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
         # build autover package so it's available for pip...
         - python setup.py bdist_wheel
         # ...and install from local dir only
-        - pip install -f file://${TRAVIS_BUILD_DIR}/dist --pre --no-index git+file:///tmp/123
+        - pushd /tmp && pip install -f file://${TRAVIS_BUILD_DIR}/dist --pre --no-index git+file:///tmp/123 && popd
       script: doit $DIR_EXAMPLE verify_installed_version --example=$EXAMPLE --example-pkgname=$EXAMPLE_PKGNAME
 
 
@@ -108,7 +108,7 @@ jobs:
       <<: *pkg_bundle
       stage: example_pipgit
       env: EXAMPLE=pkg_bundle
-      install: pip install git+file:///tmp/123
+      install: pushd /tmp && pip install git+file:///tmp/123 && popd
       script: doit $DIR_EXAMPLE verify_installed_version --example=$EXAMPLE --example-pkgname=$EXAMPLE_PKGNAME
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 stages:
   - lint
   - test
+  - check_repo_matching
   - example
   - example_pipgit
   - conda_example
@@ -248,3 +249,12 @@ jobs:
       env: NOTE="conda"
       install: true
       script: doit check_dirty_fails_conda_package
+
+
+# test of repo matching
+
+    - <<: *pkg_bundle
+      stage: check_repo_matching
+      env: EXAMPLE=pkg_bundle
+      install: true
+      script: doit $DIR_EXAMPLE check_repo_name_matching

--- a/autover/version.py
+++ b/autover/version.py
@@ -109,7 +109,7 @@ https://github.com/ioam/autover/blob/master/autover/__init__.py
 
 __author__ = 'Jean-Luc Stevens'
 
-import os, subprocess, json, traceback
+import os, subprocess, json
 
 def run_cmd(args, cwd=None):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
@@ -508,7 +508,6 @@ class Version(object):
                 with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                     f.write(json.dumps({'extracted_directory_tag':extracted_directory_tag}))
             except:
-                traceback.print_exc()
                 print('Error in setup_version: could not write .version file.')
 
 
@@ -522,7 +521,6 @@ class Version(object):
             with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                 f.write(json.dumps(info))
         except:
-            traceback.print_exc()            
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']

--- a/autover/version.py
+++ b/autover/version.py
@@ -109,7 +109,7 @@ https://github.com/ioam/autover/blob/master/autover/__init__.py
 
 __author__ = 'Jean-Luc Stevens'
 
-import os, subprocess, json
+import os, subprocess, json, traceback
 
 def run_cmd(args, cwd=None):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
@@ -508,6 +508,7 @@ class Version(object):
                 with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                     f.write(json.dumps({'extracted_directory_tag':extracted_directory_tag}))
             except:
+                traceback.print_exc()
                 print('Error in setup_version: could not write .version file.')
 
 
@@ -521,6 +522,7 @@ class Version(object):
             with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                 f.write(json.dumps(info))
         except:
+            traceback.print_exc()            
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']

--- a/autover/version.py
+++ b/autover/version.py
@@ -359,11 +359,6 @@ class Version(object):
         """
         known_stale = self._known_stale()
         if self.release is None and not known_stale:
-            # didn't find a version from git; try the .version file
-            version_info = self._output_from_file()
-            if version_info is not None:
-                self._update_from_vcs(version_info)
-        if self.release is None and not known_stale:
             extracted_directory_tag = self._output_from_file(entry='extracted_directory_tag')
             return 'None' if extracted_directory_tag is None else extracted_directory_tag
         elif self.release is None and known_stale:

--- a/autover/version.py
+++ b/autover/version.py
@@ -362,7 +362,7 @@ class Version(object):
             # didn't find a version from git; try the .version file
             version_info = self._output_from_file()
             if version_info is not None:
-                self._update_from_vcs()
+                self._update_from_vcs(version_info)
         if self.release is None and not known_stale:
             extracted_directory_tag = self._output_from_file(entry='extracted_directory_tag')
             return 'None' if extracted_directory_tag is None else extracted_directory_tag

--- a/dodo.py
+++ b/dodo.py
@@ -124,8 +124,10 @@ def task_check_dirty_fails_conda_package():
 
 def task_check_repo_name_matching():
 
+    # TODO: the splitlines() shouldn't be necessary, but autover sometimes returns other output for --version
+
     def _thing(expected,what):
-        return 'python -c \'import subprocess; v=subprocess.check_output(["python", "setup.py", "--version"]).decode().strip(); assert v.startswith("%s"), v+" does not start with %s (for %s)"\''%(expected,expected,what)
+        return 'python -c \'import subprocess; v=subprocess.check_output(["python", "setup.py", "--version"]).decode().strip().splitlines()[-1]; assert v.startswith("%s"), v+ " does not start with %s (test was for: %s)"\''%(expected,expected,what)
 
     expected_match = "0.0.1.post1+"
     expected_no_match = "None" # or 0.0.0+unknown, or what?

--- a/dodo.py
+++ b/dodo.py
@@ -120,3 +120,23 @@ def task_check_dirty_fails_conda_package():
         'teardown':[
             'python -c "print(open(\'conda-dirty-check\').read())"'
         ]}
+
+
+def task_check_repo_name_matching():
+
+    def _thing(expected,what):
+        return 'python -c \'import subprocess; v=subprocess.check_output(["python", "setup.py", "--version"]).decode().strip(); assert v.startswith("%s"), v+" does not start with %s (for %s)"\''%(expected,expected,what)
+
+    expected_match = "0.0.1.post1+"
+    expected_no_match = "None" # or 0.0.0+unknown, or what?
+
+    # not sure looking at the remotes this way makes sense - might be better to check
+    # package? (see point 2 at https://github.com/pyviz/autover/pull/55#issue-198496332)
+    return {
+        'actions':[
+            CmdAction(_thing(expected_match,"no remote")),
+            'git remote add test1 https://github.com/wrong-package',
+            CmdAction(_thing(expected_no_match,"only wrong remotes")), 
+            'git remote add test2 https://github.com/something/pkg_bundle.git',
+            CmdAction(_thing(expected_match,"one right remote"))
+        ]}

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -109,7 +109,7 @@ https://github.com/ioam/autover/blob/master/autover/__init__.py
 
 __author__ = 'Jean-Luc Stevens'
 
-import os, subprocess, json, traceback
+import os, subprocess, json
 
 def run_cmd(args, cwd=None):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
@@ -508,7 +508,6 @@ class Version(object):
                 with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                     f.write(json.dumps({'extracted_directory_tag':extracted_directory_tag}))
             except:
-                traceback.print_exc()
                 print('Error in setup_version: could not write .version file.')
 
 
@@ -522,7 +521,6 @@ class Version(object):
             with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                 f.write(json.dumps(info))
         except:
-            traceback.print_exc()            
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -109,7 +109,7 @@ https://github.com/ioam/autover/blob/master/autover/__init__.py
 
 __author__ = 'Jean-Luc Stevens'
 
-import os, subprocess, json
+import os, subprocess, json, traceback
 
 def run_cmd(args, cwd=None):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
@@ -508,6 +508,7 @@ class Version(object):
                 with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                     f.write(json.dumps({'extracted_directory_tag':extracted_directory_tag}))
             except:
+                traceback.print_exc()
                 print('Error in setup_version: could not write .version file.')
 
 
@@ -521,6 +522,7 @@ class Version(object):
             with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                 f.write(json.dumps(info))
         except:
+            traceback.print_exc()            
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -359,11 +359,6 @@ class Version(object):
         """
         known_stale = self._known_stale()
         if self.release is None and not known_stale:
-            # didn't find a version from git; try the .version file
-            version_info = self._output_from_file()
-            if version_info is not None:
-                self._update_from_vcs(version_info)
-        if self.release is None and not known_stale:
             extracted_directory_tag = self._output_from_file(entry='extracted_directory_tag')
             return 'None' if extracted_directory_tag is None else extracted_directory_tag
         elif self.release is None and known_stale:

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -362,7 +362,7 @@ class Version(object):
             # didn't find a version from git; try the .version file
             version_info = self._output_from_file()
             if version_info is not None:
-                self._update_from_vcs()
+                self._update_from_vcs(version_info)
         if self.release is None and not known_stale:
             extracted_directory_tag = self._output_from_file(entry='extracted_directory_tag')
             return 'None' if extracted_directory_tag is None else extracted_directory_tag

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -109,7 +109,7 @@ https://github.com/ioam/autover/blob/master/autover/__init__.py
 
 __author__ = 'Jean-Luc Stevens'
 
-import os, subprocess, json, traceback
+import os, subprocess, json
 
 def run_cmd(args, cwd=None):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
@@ -508,7 +508,6 @@ class Version(object):
                 with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                     f.write(json.dumps({'extracted_directory_tag':extracted_directory_tag}))
             except:
-                traceback.print_exc()
                 print('Error in setup_version: could not write .version file.')
 
 
@@ -522,7 +521,6 @@ class Version(object):
             with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                 f.write(json.dumps(info))
         except:
-            traceback.print_exc()            
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -109,7 +109,7 @@ https://github.com/ioam/autover/blob/master/autover/__init__.py
 
 __author__ = 'Jean-Luc Stevens'
 
-import os, subprocess, json
+import os, subprocess, json, traceback
 
 def run_cmd(args, cwd=None):
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
@@ -508,6 +508,7 @@ class Version(object):
                 with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                     f.write(json.dumps({'extracted_directory_tag':extracted_directory_tag}))
             except:
+                traceback.print_exc()
                 print('Error in setup_version: could not write .version file.')
 
 
@@ -521,6 +522,7 @@ class Version(object):
             with open(os.path.join(setup_path, pkgname, '.version'), 'w') as f:
                 f.write(json.dumps(info))
         except:
+            traceback.print_exc()            
             print('Error in setup_version: could not write .version file.')
 
         return info['version_string']

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -359,11 +359,6 @@ class Version(object):
         """
         known_stale = self._known_stale()
         if self.release is None and not known_stale:
-            # didn't find a version from git; try the .version file
-            version_info = self._output_from_file()
-            if version_info is not None:
-                self._update_from_vcs(version_info)
-        if self.release is None and not known_stale:
             extracted_directory_tag = self._output_from_file(entry='extracted_directory_tag')
             return 'None' if extracted_directory_tag is None else extracted_directory_tag
         elif self.release is None and known_stale:

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -362,7 +362,7 @@ class Version(object):
             # didn't find a version from git; try the .version file
             version_info = self._output_from_file()
             if version_info is not None:
-                self._update_from_vcs()
+                self._update_from_vcs(version_info)
         if self.release is None and not known_stale:
             extracted_directory_tag = self._output_from_file(entry='extracted_directory_tag')
             return 'None' if extracted_directory_tag is None else extracted_directory_tag


### PR DESCRIPTION
Try to fix repo name matching (see #54).

-----

Original comment when title was "If there's no version info from git, try the .version file." 

* If no version info came back from git, try a .version file. 
* Also, fix check that remote matches repo name.

See #54

I ought to add some tests, but that could be even more time consuming, so I want to wait until some review/agreement about behavior.

My opinion about what's future work, beyond this PR:

1. I think that if present, the .version file should be the only thing used to get the version. I think this means that the .version file should only be present in packages (or other situations where a static version is required, if there are any).

2. I think the detection of the git repository should be tightened up, if possible. So not just trying to run git, but maybe also: check for .git in the same location as the named python package (and have this controlled by an optional "relative path between .git and the package" parameter, defaulting to `.`, but which could be set to e.g. `src/` or whatever). (Maybe there are situations I'm not thinking about. I did think briefly about submodules, and though I don't remember the details of submodules, I think there's a .git in a submodule.)
