### PR TITLE
Update miniconda download url.

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -15,8 +15,14 @@ miniconda_url = {
     "Linux": "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh",
     "Darwin": "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 }
-def task_miniconda_download():
-    """Download Miniconda3-latest"""
+def task_download_miniconda():
+    import platform
+
+    try:
+        from urllib.request import urlretrieve
+    except ImportError:
+        from urllib import urlretrieve
+    
     url = miniconda_url[platform.system()]
     miniconda_installer = url.split('/')[-1]
 

--- a/dodo.py
+++ b/dodo.py
@@ -8,6 +8,25 @@ from doit import action
 
 from pyct import *  # noqa
 
+############################################################
+# TODO: remove if project is updated to use pyctdev
+miniconda_url = {
+    "Windows": "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe",
+    "Linux": "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh",
+    "Darwin": "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+}
+def task_miniconda_download():
+    """Download Miniconda3-latest"""
+    url = miniconda_url[platform.system()]
+    miniconda_installer = url.split('/')[-1]
+
+    def download_miniconda(targets):
+        urlretrieve(url,miniconda_installer)
+
+    return {'targets': [miniconda_installer],
+            'uptodate': [True], # (as has no deps)
+            'actions': [download_miniconda]}
+############################################################
 
 example = {
     'name':'example',


### PR DESCRIPTION
Autover is using a very old version of pyctdev - from when it was still called pyct - and the miniconda download url has changed from continuum to anaconda.