### PR TITLE
Fixed check on remote to avoid issue with nested repos

### DIFF
--- a/autover/version.py
+++ b/autover/version.py
@@ -254,24 +254,22 @@ class Version(object):
                 # Verify this is the correct repository (since fpath could
                 # be an unrelated git repository, and autover could just have
                 # been copied/installed into it).
-                output = run_cmd([cmd, 'remote', '-v'],
-                                 cwd=os.path.dirname(self.fpath))
+                remotes = run_cmd([cmd, 'remote', '-v'],
+                                  cwd=os.path.dirname(self.fpath))
                 repo_matches = ['/' + self.reponame + '.git' ,
                                 # A remote 'server:reponame.git' can also be referred
                                 # to (i.e. cloned) as `server:reponame`.
                                 '/' + self.reponame + ' ']
-                if not any(m in output for m in repo_matches):
+                if not any(m in remotes for m in repo_matches):
                     try:
                         output = self._output_from_file()
                         if output is not None:
                             self._update_from_vcs(output)
-                            return self
-                    except:
-                        pass
-
-            output = run_cmd([cmd, 'describe', '--long', '--match',
-                              "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
-                             cwd=os.path.dirname(self.fpath))
+                    except: pass
+            if output is None:
+                output = run_cmd([cmd, 'describe', '--long', '--match',
+                                  "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
+                                 cwd=os.path.dirname(self.fpath))
             if as_string: return output
         except Exception as e1:
             try:

--- a/autover/version.py
+++ b/autover/version.py
@@ -256,12 +256,15 @@ class Version(object):
                 # been copied/installed into it).
                 output = run_cmd([cmd, 'remote', '-v'],
                                  cwd=os.path.dirname(self.fpath))
-                repo_matches = ['', # No remote set
-                                '/' + self.reponame + '.git' ,
+                repo_matches = ['/' + self.reponame + '.git' ,
                                 # A remote 'server:reponame.git' can also be referred
                                 # to (i.e. cloned) as `server:reponame`.
                                 '/' + self.reponame + ' ']
                 if not any(m in output for m in repo_matches):
+                    try:
+                        self._update_from_vcs(self._output_from_file())
+                    except:
+                        pass
                     return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match',

--- a/autover/version.py
+++ b/autover/version.py
@@ -263,9 +263,9 @@ class Version(object):
                 if not any(m in output for m in repo_matches):
                     try:
                         self._update_from_vcs(self._output_from_file())
+                        return self
                     except:
                         pass
-                    return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match',
                               "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],

--- a/autover/version.py
+++ b/autover/version.py
@@ -262,8 +262,10 @@ class Version(object):
                                 '/' + self.reponame + ' ']
                 if not any(m in output for m in repo_matches):
                     try:
-                        self._update_from_vcs(self._output_from_file())
-                        return self
+                        output = self._output_from_file()
+                        if output is not None:
+                            self._update_from_vcs(output)
+                            return self
                     except:
                         pass
 

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -254,24 +254,22 @@ class Version(object):
                 # Verify this is the correct repository (since fpath could
                 # be an unrelated git repository, and autover could just have
                 # been copied/installed into it).
-                output = run_cmd([cmd, 'remote', '-v'],
-                                 cwd=os.path.dirname(self.fpath))
+                remotes = run_cmd([cmd, 'remote', '-v'],
+                                  cwd=os.path.dirname(self.fpath))
                 repo_matches = ['/' + self.reponame + '.git' ,
                                 # A remote 'server:reponame.git' can also be referred
                                 # to (i.e. cloned) as `server:reponame`.
                                 '/' + self.reponame + ' ']
-                if not any(m in output for m in repo_matches):
+                if not any(m in remotes for m in repo_matches):
                     try:
                         output = self._output_from_file()
                         if output is not None:
                             self._update_from_vcs(output)
-                            return self
-                    except:
-                        pass
-
-            output = run_cmd([cmd, 'describe', '--long', '--match',
-                              "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
-                             cwd=os.path.dirname(self.fpath))
+                    except: pass
+            if output is None:
+                output = run_cmd([cmd, 'describe', '--long', '--match',
+                                  "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
+                                 cwd=os.path.dirname(self.fpath))
             if as_string: return output
         except Exception as e1:
             try:

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -256,12 +256,15 @@ class Version(object):
                 # been copied/installed into it).
                 output = run_cmd([cmd, 'remote', '-v'],
                                  cwd=os.path.dirname(self.fpath))
-                repo_matches = ['', # No remote set
-                                '/' + self.reponame + '.git' ,
+                repo_matches = ['/' + self.reponame + '.git' ,
                                 # A remote 'server:reponame.git' can also be referred
                                 # to (i.e. cloned) as `server:reponame`.
                                 '/' + self.reponame + ' ']
                 if not any(m in output for m in repo_matches):
+                    try:
+                        self._update_from_vcs(self._output_from_file())
+                    except:
+                        pass
                     return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match',

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -263,9 +263,9 @@ class Version(object):
                 if not any(m in output for m in repo_matches):
                     try:
                         self._update_from_vcs(self._output_from_file())
+                        return self
                     except:
                         pass
-                    return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match',
                               "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],

--- a/examples/PkgBundle/version.py
+++ b/examples/PkgBundle/version.py
@@ -262,8 +262,10 @@ class Version(object):
                                 '/' + self.reponame + ' ']
                 if not any(m in output for m in repo_matches):
                     try:
-                        self._update_from_vcs(self._output_from_file())
-                        return self
+                        output = self._output_from_file()
+                        if output is not None:
+                            self._update_from_vcs(output)
+                            return self
                     except:
                         pass
 

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -254,24 +254,22 @@ class Version(object):
                 # Verify this is the correct repository (since fpath could
                 # be an unrelated git repository, and autover could just have
                 # been copied/installed into it).
-                output = run_cmd([cmd, 'remote', '-v'],
-                                 cwd=os.path.dirname(self.fpath))
+                remotes = run_cmd([cmd, 'remote', '-v'],
+                                  cwd=os.path.dirname(self.fpath))
                 repo_matches = ['/' + self.reponame + '.git' ,
                                 # A remote 'server:reponame.git' can also be referred
                                 # to (i.e. cloned) as `server:reponame`.
                                 '/' + self.reponame + ' ']
-                if not any(m in output for m in repo_matches):
+                if not any(m in remotes for m in repo_matches):
                     try:
                         output = self._output_from_file()
                         if output is not None:
                             self._update_from_vcs(output)
-                            return self
-                    except:
-                        pass
-
-            output = run_cmd([cmd, 'describe', '--long', '--match',
-                              "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
-                             cwd=os.path.dirname(self.fpath))
+                    except: pass
+            if output is None:
+                output = run_cmd([cmd, 'describe', '--long', '--match',
+                                  "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
+                                 cwd=os.path.dirname(self.fpath))
             if as_string: return output
         except Exception as e1:
             try:

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -256,12 +256,15 @@ class Version(object):
                 # been copied/installed into it).
                 output = run_cmd([cmd, 'remote', '-v'],
                                  cwd=os.path.dirname(self.fpath))
-                repo_matches = ['', # No remote set
-                                '/' + self.reponame + '.git' ,
+                repo_matches = ['/' + self.reponame + '.git' ,
                                 # A remote 'server:reponame.git' can also be referred
                                 # to (i.e. cloned) as `server:reponame`.
                                 '/' + self.reponame + ' ']
                 if not any(m in output for m in repo_matches):
+                    try:
+                        self._update_from_vcs(self._output_from_file())
+                    except:
+                        pass
                     return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match',

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -263,9 +263,9 @@ class Version(object):
                 if not any(m in output for m in repo_matches):
                     try:
                         self._update_from_vcs(self._output_from_file())
+                        return self
                     except:
                         pass
-                    return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match',
                               "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],

--- a/examples/pkg_bundle/version.py
+++ b/examples/pkg_bundle/version.py
@@ -262,8 +262,10 @@ class Version(object):
                                 '/' + self.reponame + ' ']
                 if not any(m in output for m in repo_matches):
                     try:
-                        self._update_from_vcs(self._output_from_file())
-                        return self
+                        output = self._output_from_file()
+                        if output is not None:
+                            self._update_from_vcs(output)
+                            return self
                     except:
                         pass
 


### PR DESCRIPTION
The offending line was:

```
repo_matches = ['', # No remote set
```

As an empty string will always be in whatever output `git remote -v` returns. After that, if the remotes don't match what the current repo is supposed to be called, an attempt is made to load the state from the `.version` file.

Should fix https://github.com/pyviz-dev/autover/issues/54